### PR TITLE
Fixed overlapping y axis

### DIFF
--- a/tfbpshiny/utils/create_distribution_plot.py
+++ b/tfbpshiny/utils/create_distribution_plot.py
@@ -82,6 +82,7 @@ def create_distribution_plot(
         y=y_column,
         color="binding_source",
         facet_col="expression_source",
+        facet_col_spacing=0.04,
         points="outliers",
         category_orders=category_orders,
         color_discrete_map=color_discrete_map,

--- a/tfbpshiny/utils/create_distribution_plot.py
+++ b/tfbpshiny/utils/create_distribution_plot.py
@@ -87,4 +87,4 @@ def create_distribution_plot(
         color_discrete_map=color_discrete_map,
     )
 
-    return plot_formatter(fig, y_axis_title, **kwargs)
+    return plot_formatter(fig, "Binding Data Source", y_axis_title, **kwargs)

--- a/tfbpshiny/utils/plot_formatter.py
+++ b/tfbpshiny/utils/plot_formatter.py
@@ -3,11 +3,29 @@ from plotly.graph_objects import Figure
 
 def plot_formatter(
     fig: Figure,
+    x_axis_title: str | None = None,
     y_axis_title: str | None = None,
     show_legend: bool = True,
 ) -> Figure:
+    """
+    Format a plotly figure with consistent formatting.
+
+    :param fig: The figure to format.
+    :param x_axis_title: The title for the x-axis.
+    :param y_axis_title: The title for the y-axis.
+    :param show_legend: Whether to show the legend.
+    :return: The formatted figure.
+    :raises ValueError: If the figure is not a plotly.graph_objs.Figure object or the
+        x_axis_title or y_axis_title is not a string or None.
+    :raises TypeError: If the input fig is not a Plotly Figure object or x_axis_title or
+        y_axis_title is not a string.
+
+    """
+
     if not isinstance(fig, Figure):
         raise ValueError("fig must be a plotly.graph_objs.Figure object")
+    if x_axis_title and not isinstance(x_axis_title, str):
+        raise ValueError("x_axis_title must be a string or None")
     if y_axis_title and not isinstance(y_axis_title, str):
         raise ValueError("y_axis_title must be a string or None")
 
@@ -42,6 +60,10 @@ def plot_formatter(
     # Optional y-axis title
     if y_axis_title:
         fig.update_yaxes(title=y_axis_title)
+
+    # Optional x-axis title
+    if x_axis_title:
+        fig.update_xaxes(title=x_axis_title)
 
     # Simplify facet strip text
     # (e.g., "expression_source=Overexpression" to "Overexpression")


### PR DESCRIPTION
1. Fixed y-axis on facet plots by setting `facet_col_spacing=0.04`. For more details, please see **Controlling Facet Spacing** via [facet-plots](https://plotly.com/python/facet-plots/)
2. Updated the x-axis by introducing a new parameter in plot_formatter so that the name of x-axis can be customized.

close #60 