### PR TITLE
ensure rr plots' consistency.

### DIFF
--- a/tfbpshiny/rank_response/replicate_plot_module.py
+++ b/tfbpshiny/rank_response/replicate_plot_module.py
@@ -383,10 +383,16 @@ def rank_response_replicate_plot_server(
         metadata = rr_dict.get("metadata")
         rr_metadata.set(metadata)
         expression_sources = metadata["expression_source"].unique()
+        # Sort the expression sources alphabetically for consistent plot order
+        sorted_expression_sources = sorted(list(expression_sources))
+        logger.info(
+            "Derived and sorted expression_sources order: %s",
+            list(sorted_expression_sources),
+        )
 
         plot_dict_by_source = {}
         promotersetsig_set = set()
-        for source in expression_sources:
+        for source in sorted_expression_sources:  # Iterate over the sorted list
             filtered_metadata = metadata[metadata["expression_source"] == source]
             try:
                 promotersetsig_set.update(


### PR DESCRIPTION
This inconsistency of plot sequence was caused by pd.Series.unique(), which returns unique values in the order of their first appearance in the Series. By sorting the expression sources, 2014TFKO stays on the left and Overexpression stays on the right. 

I also noticed that there was a significant performance issue while selecting YDR423C in the tab (I was comparing the plots for YDR443C and YDR423C). I'm wondering if adding a caching mechanism would be beneficial if a user wanted to select back and forth between two regulators. 