### PR TITLE
Redesign Individual RR tab

### DIFF
--- a/tfbpshiny/rank_response/expression_source_table_module.py
+++ b/tfbpshiny/rank_response/expression_source_table_module.py
@@ -1,0 +1,105 @@
+from logging import Logger
+
+from shiny import Inputs, Outputs, Session, module, reactive, render, req, ui
+
+from ..utils.rename_dataframe_data_sources import rename_dataframe_data_sources
+from ..utils.safe_sci_notatation import safe_sci_notation
+
+
+@module.ui
+def expression_source_table_ui():
+    return ui.output_data_frame("expression_source_table")
+
+
+@module.server
+def expression_source_table_server(
+    input: Inputs,
+    output: Outputs,
+    session: Session,
+    *,
+    rr_metadata: reactive.calc,
+    expression_source: str,
+    selected_promotersetsigs: reactive.value,
+    selected_columns: reactive.calc,
+    logger: Logger,
+) -> None:
+    """
+    Server for expression source specific table.
+
+    :param rr_metadata: Complete rank response metadata
+    :param expression_source: The specific expression source to filter for
+    :param selected_promotersetsigs: Reactive value containing selected promotersetsigs
+    :param selected_columns: Reactive calc containing selected columns to display
+    :param logger: Logger object
+
+    """
+
+    @render.data_frame
+    def expression_source_table():
+        req(rr_metadata)
+        req(selected_columns)
+
+        df_local = rr_metadata().copy()  # type: ignore
+
+        # Filter for specific expression source
+        df_local = df_local[df_local["expression_source"] == expression_source]
+
+        # Get selected promotersetsigs for highlighting
+        selected_promotersetsigs_local = selected_promotersetsigs.get()
+
+        # Get selected columns from the accordion
+        selected_cols = selected_columns()
+
+        # Always include promotersetsig (needed for highlighting logic)
+        columns_to_show = ["promotersetsig"] + [
+            col for col in selected_cols if col != "promotersetsig"
+        ]
+
+        # Filter to only show columns that exist in the dataframe and are selected
+        available_columns = [col for col in columns_to_show if col in df_local.columns]
+
+        if available_columns:
+            df_local = df_local[available_columns]
+
+        df_local = rename_dataframe_data_sources(df_local)
+
+        # Format numeric columns
+        cols_to_format = [
+            "univariate_pvalue",
+            "univariate_rsquared",
+            "dto_fdr",
+            "dto_empirical_pvalue",
+            "random_expectation",
+            "rank_25",
+            "rank_50",
+        ]
+
+        existing_numeric_cols = [
+            col for col in cols_to_format if col in df_local.columns
+        ]
+        if existing_numeric_cols:
+            df_local[existing_numeric_cols] = df_local[existing_numeric_cols].applymap(
+                safe_sci_notation
+            )
+
+        df_local.reset_index(drop=True, inplace=True)
+
+        # Create styles for highlighting rows that match selection
+        styles = None
+        if selected_promotersetsigs_local:
+            matching_rows = df_local[
+                df_local["promotersetsig"].isin(selected_promotersetsigs_local)
+            ].index.tolist()
+
+            if matching_rows:
+                styles = {
+                    "rows": matching_rows,
+                    "cols": list(range(len(df_local.columns))),
+                    "style": {"background-color": "#e6fffa"},
+                }
+
+        return render.DataGrid(
+            df_local,
+            selection_mode="none",
+            styles=[styles] if styles else [],
+        )

--- a/tfbpshiny/rank_response/main_table_module.py
+++ b/tfbpshiny/rank_response/main_table_module.py
@@ -1,0 +1,102 @@
+from logging import Logger
+
+from shiny import Inputs, Outputs, Session, module, reactive, render, req, ui
+
+from ..utils.rename_dataframe_data_sources import rename_dataframe_data_sources
+
+
+@module.ui
+def main_table_ui():
+    return ui.output_data_frame("main_table")
+
+
+@module.server
+def main_table_server(
+    input: Inputs,
+    output: Outputs,
+    session: Session,
+    *,
+    rr_metadata: reactive.calc,
+    bindingmanualqc_result: reactive.ExtendedTask,
+    logger: Logger,
+) -> reactive.calc:
+    """
+    Main table server showing promotersetsig, binding_source, insert columns, and QC
+    columns.
+
+    :param rr_metadata: Complete rank response metadata
+    :param bindingmanualqc_result: Binding manual QC data
+    :param logger: Logger object
+    :return: Reactive calc returning selected promotersetsigs
+
+    """
+
+    df_local_reactive = reactive.Value()
+
+    @render.data_frame
+    def main_table():
+        req(rr_metadata)
+        rr_df = rr_metadata().copy()  # type: ignore
+
+        qc_df = bindingmanualqc_result.result()
+
+        # Get unique combinations with insert columns
+        main_df = rr_df[
+            [
+                "promotersetsig",
+                "binding_source",
+                "single_binding",
+                "composite_binding",
+                "genomic_inserts",
+                "mito_inserts",
+                "plasmid_inserts",
+            ]
+        ].drop_duplicates()
+
+        # Merge with QC data
+        if "rank_response_status" in qc_df.columns and "dto_status" in qc_df.columns:
+            qc_subset = qc_df[
+                [
+                    "single_binding",
+                    "composite_binding",
+                    "rank_response_status",
+                    "dto_status",
+                ]
+            ].drop_duplicates()
+            main_df = main_df.merge(
+                qc_subset, on=["single_binding", "composite_binding"], how="left"
+            )
+
+        # Reorder columns with promotersetsig first
+        display_columns = [
+            "promotersetsig",
+            "binding_source",
+            "genomic_inserts",
+            "mito_inserts",
+            "plasmid_inserts",
+            "rank_response_status",
+            "dto_status",
+        ]
+        existing_columns = [col for col in display_columns if col in main_df.columns]
+        main_df = main_df[existing_columns]
+
+        main_df = rename_dataframe_data_sources(main_df)
+        main_df.reset_index(drop=True, inplace=True)
+
+        df_local_reactive.set(main_df)
+
+        return render.DataGrid(
+            main_df,
+            selection_mode="rows",
+        )
+
+    @reactive.calc
+    def get_selected_promotersetsigs():
+        req(df_local_reactive)
+        selected_rows = main_table.cell_selection()["rows"]
+        df_local = df_local_reactive.get()
+        if not selected_rows or df_local.empty:
+            return set()
+        return set(df_local.loc[list(selected_rows), "promotersetsig"])
+
+    return get_selected_promotersetsigs


### PR DESCRIPTION
1. Split RR table into Main Selection table and Replicate Details table. 
2. Added highlight to linked selected rows in Replicate Details table. 
3. Aligned the two tables horizontally and added description in their footer.