### PR TITLE
refactor: remove camelCase duplicate keys from dataset dicts

### DIFF
--- a/docs/REACTIVITY.md
+++ b/docs/REACTIVITY.md
@@ -167,8 +167,8 @@ on_cell_click(payload) callback -> app_server
     |
     v
 intersection_detail.set({                            [app.py]
-    rowDataset: {id, dbName, type, name, tfCount},
-    colDataset: {id, dbName, type, name, tfCount},
+    rowDataset: {id, db_name, type, name, tf_count},
+    colDataset: {id, db_name, type, name, tf_count},
     intersectionCount: count
 })
     |

--- a/tfbpshiny/app.py
+++ b/tfbpshiny/app.py
@@ -193,7 +193,7 @@ def app_server(
 
         for entry in selected:
             dataset_id = str(entry["id"])
-            db_name = str(entry.get("db_name") or entry.get("dbName"))
+            db_name = str(entry.get("db_name"))
             normalized = normalize_dataset_filters(filters.get(dataset_id, {}))
             if normalized["categorical"]:
                 categorical_payload[db_name] = normalized["categorical"]
@@ -248,21 +248,14 @@ def app_server(
 
             # Build a VirtualDB containing at least this dataset.
             selected = _selected_datasets()
-            selected_db_names = [
-                str(e.get("db_name") or e.get("dbName")) for e in selected
-            ]
-            ds_db_name = str(dataset.get("db_name") or dataset.get("dbName"))
+            selected_db_names = [str(e.get("db_name")) for e in selected]
+            ds_db_name = str(dataset.get("db_name"))
             all_db_names = sorted(set(selected_db_names + [ds_db_name]))
             vdb = get_or_create_vdb(all_db_names)
 
-            metadata_configs = (
-                dataset.get("metadata_configs") or dataset.get("metadataConfigs") or []
-            )
+            metadata_configs = dataset.get("metadata_configs") or []
             if metadata_configs:
-                meta_table = str(
-                    metadata_configs[0].get("dbName")
-                    or metadata_configs[0].get("db_name")
-                )
+                meta_table = str(metadata_configs[0].get("db_name"))
             else:
                 meta_table = f"{ds_db_name}_meta"
 
@@ -290,9 +283,7 @@ def app_server(
 
     def _handle_refresh_intersection() -> None:
         selected = _selected_datasets()
-        selected_db_names = [
-            str(entry.get("db_name") or entry.get("dbName")) for entry in selected
-        ]
+        selected_db_names = [str(entry.get("db_name")) for entry in selected]
 
         if not selected_db_names:
             intersection_cells.set([])
@@ -310,7 +301,7 @@ def app_server(
             column_counts: dict[str, int | None] = {}
             for entry in selected:
                 dataset_id = str(entry["id"])
-                db_name = str(entry.get("db_name") or entry.get("dbName"))
+                db_name = str(entry.get("db_name"))
                 dataset_type = str(entry.get("type", ""))
                 try:
                     # For binding datasets, count distinct samples.
@@ -335,12 +326,9 @@ def app_server(
 
                 next_entry = dict(entry)
                 next_entry["sample_count"] = sample_count
-                next_entry["sampleCount"] = sample_count
                 next_entry["sample_count_known"] = True
-                next_entry["sampleCountKnown"] = True
                 if column_count is not None:
                     next_entry["column_count"] = column_count
-                    next_entry["columnCount"] = column_count
                 updated_datasets.append(next_entry)
 
             payloads = _selected_filter_payloads()
@@ -360,7 +348,7 @@ def app_server(
 
             final_datasets = []
             for entry in updated_datasets:
-                db_name = str(entry.get("db_name") or entry.get("dbName"))
+                db_name = str(entry.get("db_name"))
                 if db_name not in tf_count_by_db_name:
                     final_datasets.append(entry)
                     continue
@@ -368,9 +356,7 @@ def app_server(
                 next_entry = dict(entry)
                 tf_count = int(tf_count_by_db_name[db_name])
                 next_entry["tf_count"] = tf_count
-                next_entry["tfCount"] = tf_count
                 next_entry["tf_count_known"] = True
-                next_entry["tfCountKnown"] = True
                 next_entry["gene_count"] = tf_count
                 final_datasets.append(next_entry)
 
@@ -565,18 +551,18 @@ def app_server(
         intersection_count = int(details.get("intersectionCount") or 0)
         row_type = str(row_dataset.get("type", "Expression"))
         col_type = str(col_dataset.get("type", "Expression"))
-        row_db_name = str(row_dataset.get("dbName", ""))
-        col_db_name = str(col_dataset.get("dbName", ""))
+        row_db_name = str(row_dataset.get("db_name", ""))
+        col_db_name = str(col_dataset.get("db_name", ""))
 
         payload: dict[str, Any] = {
             "rowDataset": {
                 "id": str(row_dataset.get("id", "")),
-                "dbName": row_db_name,
+                "db_name": row_db_name,
                 "type": row_type,
             },
             "colDataset": {
                 "id": str(col_dataset.get("id", "")),
-                "dbName": col_db_name,
+                "db_name": col_db_name,
                 "type": col_type,
             },
             "intersectionCount": intersection_count,

--- a/tfbpshiny/data_service.py
+++ b/tfbpshiny/data_service.py
@@ -67,7 +67,7 @@ def _infer_dataset_type(
         return "Binding"
     if _PERTURBATION_KEYWORDS.search(haystack):
         return "Perturbation"
-    return "Expression"
+    return "Unknown"
 
 
 def _dataset_group_and_badge(dataset_type: str) -> tuple[str, str]:
@@ -77,7 +77,7 @@ def _dataset_group_and_badge(dataset_type: str) -> tuple[str, str]:
         return ("perturbation", "PR")
     if dataset_type == "Comparative":
         return ("comparative", "CO")
-    return ("expression", "EX")
+    return ("unknown", "UK")
 
 
 def _title_case(raw: str) -> str:
@@ -124,13 +124,13 @@ def get_datasets(yaml_path: Path | str | None = None) -> list[dict[str, Any]]:
             meta_db_name = f"{db_name}_meta"
             metadata_configs = [
                 {
-                    "configName": f"{config_name}_meta",
-                    "dbName": meta_db_name,
-                    "sampleIdField": "sample_id",
-                    "sampleCount": 0,
-                    "sampleCountKnown": False,
-                    "columnCount": 0,
-                    "columnNames": [],
+                    "config_name": f"{config_name}_meta",
+                    "db_name": meta_db_name,
+                    "sample_id_field": "sample_id",
+                    "sample_count": 0,
+                    "sample_count_known": False,
+                    "column_count": 0,
+                    "column_names": [],
                 }
             ]
 
@@ -138,31 +138,20 @@ def get_datasets(yaml_path: Path | str | None = None) -> list[dict[str, Any]]:
                 {
                     "id": dataset_id,
                     "db_name": db_name,
-                    "dbName": db_name,
                     "repo_id": repo_id,
-                    "repoId": repo_id,
                     "config_name": config_name,
-                    "configName": config_name,
                     "name": display_name,
                     "type": dataset_type,
                     "group": group,
                     "type_badge": type_badge,
-                    "typeBadge": type_badge,
                     "sample_count": 0,
-                    "sampleCount": 0,
                     "sample_count_known": False,
-                    "sampleCountKnown": False,
                     "column_count": 0,
-                    "columnCount": 0,
                     "column_names": [],
-                    "columnNames": [],
                     "gene_count": 0,
                     "tf_count": 0,
-                    "tfCount": 0,
                     "tf_count_known": False,
-                    "tfCountKnown": False,
                     "metadata_configs": metadata_configs,
-                    "metadataConfigs": metadata_configs,
                     "metadata": {
                         "source": repo_id,
                         "meta_table": meta_db_name,
@@ -789,6 +778,12 @@ def get_median_correlation_matrix(
                 else:
                     # Use mean: deterministic, appropriate for continuous values
                     tf_target_map[tf][tgt] = sum(vals) / len(vals)
+
+        if not tf_target_map:
+            logger.debug(
+                "Dataset %s has no valid TF-target data after null filtering", db_name
+            )
+            continue
 
         dataset_data[db_name] = tf_target_map
         valid_db_names.append(db_name)

--- a/tfbpshiny/mock_data.py
+++ b/tfbpshiny/mock_data.py
@@ -660,17 +660,18 @@ def get_mock_datasets() -> list[dict[str, Any]]:
         for supplemental in entry.get("supplemental_configs", []):
             metadata_configs.append(
                 {
-                    "configName": supplemental.get("config_name"),
-                    "dbName": supplemental.get("db_name"),
-                    "sampleIdField": supplemental.get("sample_id_field"),
-                    "sampleCount": supplemental.get("estimated_rows") or 0,
-                    "sampleCountKnown": supplemental.get("estimated_rows") is not None,
-                    "columnCount": (
+                    "config_name": supplemental.get("config_name"),
+                    "db_name": supplemental.get("db_name"),
+                    "sample_id_field": supplemental.get("sample_id_field"),
+                    "sample_count": supplemental.get("estimated_rows") or 0,
+                    "sample_count_known": supplemental.get("estimated_rows")
+                    is not None,
+                    "column_count": (
                         supplemental.get("num_columns")
                         if isinstance(supplemental.get("num_columns"), int)
                         else len(supplemental.get("column_names") or [])
                     ),
-                    "columnNames": supplemental.get("column_names") or [],
+                    "column_names": supplemental.get("column_names") or [],
                 }
             )
 
@@ -682,43 +683,28 @@ def get_mock_datasets() -> list[dict[str, Any]]:
             {
                 "id": str(entry["id"]),
                 "db_name": db_name,
-                "dbName": db_name,
                 "repo_id": entry.get("repo_id"),
-                "repoId": entry.get("repo_id"),
                 "config_name": entry.get("config_name"),
-                "configName": entry.get("config_name"),
                 "name": entry.get("name")
                 or _title_case(entry.get("config_name", db_name)),
                 "type": dataset_type,
                 "group": group,
                 "type_badge": type_badge,
-                "typeBadge": type_badge,
                 "sample_count": (
                     estimated_rows if isinstance(estimated_rows, int) else 0
                 ),
-                "sampleCount": estimated_rows if isinstance(estimated_rows, int) else 0,
                 "sample_count_known": isinstance(estimated_rows, int),
-                "sampleCountKnown": isinstance(estimated_rows, int),
                 "column_count": (
                     num_columns if isinstance(num_columns, int) else len(column_names)
                 ),
-                "columnCount": (
-                    num_columns if isinstance(num_columns, int) else len(column_names)
-                ),
                 "column_names": column_names,
-                "columnNames": column_names,
-                # Legacy aliases retained for compatibility with existing modules.
                 "gene_count": unique_tf_count,
                 "col_count": (
                     num_columns if isinstance(num_columns, int) else len(column_names)
                 ),
-                # Intersection-derived counts start as unknown and get set on refresh.
                 "tf_count": 0,
-                "tfCount": 0,
                 "tf_count_known": False,
-                "tfCountKnown": False,
                 "metadata_configs": metadata_configs,
-                "metadataConfigs": metadata_configs,
                 "metadata": {
                     "source": entry.get("repo_id", "mock"),
                     "meta_table": f"{db_name}_meta",
@@ -979,9 +965,7 @@ def compute_mock_intersection(
     """
     _ = logic_mode
     selected = [entry for entry in datasets if entry.get("selected")]
-    selected_db_names = [
-        str(entry.get("db_name") or entry.get("dbName")) for entry in selected
-    ]
+    selected_db_names = [str(entry.get("db_name")) for entry in selected]
     cells = get_mock_intersection_cells(selected_db_names)
 
     names = [str(entry.get("name", entry.get("db_name"))) for entry in selected]

--- a/tfbpshiny/modules/analysis_workspace.py
+++ b/tfbpshiny/modules/analysis_workspace.py
@@ -83,9 +83,7 @@ def analysis_workspace_server(
     def _resolve_dataset_pair() -> tuple[str, str, bool]:
         config = analysis_config()
         relevant = _relevant_datasets()
-        db_names = [
-            str(dataset.get("db_name") or dataset.get("dbName")) for dataset in relevant
-        ]
+        db_names = [str(dataset.get("db_name")) for dataset in relevant]
 
         selected_db = str(config.get("selected_db_name", ""))
         if selected_db not in db_names:
@@ -127,9 +125,7 @@ def analysis_workspace_server(
             return None
 
         relevant = _relevant_datasets()
-        db_names = [
-            str(dataset.get("db_name") or dataset.get("dbName")) for dataset in relevant
-        ]
+        db_names = [str(dataset.get("db_name")) for dataset in relevant]
 
         if len(db_names) < 2:
             return None

--- a/tfbpshiny/modules/modals.py
+++ b/tfbpshiny/modules/modals.py
@@ -242,11 +242,9 @@ def render_dataset_config_modal(
     badge_text, badge_class = _dataset_type_badge(
         str(dataset.get("type", "Expression"))
     )
-    sample_count = int(dataset.get("sample_count") or dataset.get("sampleCount") or 0)
-    sample_count_known = bool(
-        dataset.get("sample_count_known") or dataset.get("sampleCountKnown")
-    )
-    column_count = int(dataset.get("column_count") or dataset.get("columnCount") or 0)
+    sample_count = int(dataset.get("sample_count") or 0)
+    sample_count_known = bool(dataset.get("sample_count_known"))
+    column_count = int(dataset.get("column_count") or 0)
 
     option_sections: list[ui.Tag] = []
 
@@ -472,8 +470,8 @@ def render_intersection_detail_modal(details: dict[str, Any]) -> ui.Tag:
     col_dataset = details["colDataset"]
     count = int(details.get("intersectionCount") or 0)
 
-    row_tf_count = int(row_dataset.get("tfCount") or row_dataset.get("tf_count") or 0)
-    col_tf_count = int(col_dataset.get("tfCount") or col_dataset.get("tf_count") or 0)
+    row_tf_count = int(row_dataset.get("tf_count") or 0)
+    col_tf_count = int(col_dataset.get("tf_count") or 0)
 
     row_pct = "N/A" if row_tf_count <= 0 else f"{(count / row_tf_count) * 100:.1f}%"
     col_pct = "N/A" if col_tf_count <= 0 else f"{(count / col_tf_count) * 100:.1f}%"

--- a/tfbpshiny/modules/selection_matrix.py
+++ b/tfbpshiny/modules/selection_matrix.py
@@ -87,11 +87,11 @@ def selection_matrix_server(
 
         values: list[int] = []
         for i, row_dataset in enumerate(active):
-            row_db = str(row_dataset.get("db_name") or row_dataset.get("dbName"))
+            row_db = str(row_dataset.get("db_name"))
             for j, col_dataset in enumerate(active):
                 if j <= i:
                     continue
-                col_db = str(col_dataset.get("db_name") or col_dataset.get("dbName"))
+                col_db = str(col_dataset.get("db_name"))
                 value = cell_map.get(_cell_key(row_db, col_db))
                 if isinstance(value, int):
                     values.append(value)
@@ -106,14 +106,14 @@ def selection_matrix_server(
 
         for row_index, row_dataset in enumerate(active):
             row_id = str(row_dataset.get("id"))
-            row_db = str(row_dataset.get("db_name") or row_dataset.get("dbName"))
+            row_db = str(row_dataset.get("db_name"))
 
             for col_index, col_dataset in enumerate(active):
                 if col_index <= row_index:
                     continue
 
                 col_id = str(col_dataset.get("id"))
-                col_db = str(col_dataset.get("db_name") or col_dataset.get("dbName"))
+                col_db = str(col_dataset.get("db_name"))
                 value = cell_map.get(_cell_key(row_db, col_db))
                 if value is None:
                     continue
@@ -133,35 +133,17 @@ def selection_matrix_server(
                         payload = {
                             "rowDataset": {
                                 "id": row_id,
-                                "dbName": row_db,
+                                "db_name": row_db,
                                 "type": row_dataset.get("type", "Expression"),
                                 "name": row_dataset.get("name", row_db),
-                                "tfCount": int(
-                                    row_dataset.get("tf_count")
-                                    or row_dataset.get("tfCount")
-                                    or 0
-                                ),
-                                "tf_count": int(
-                                    row_dataset.get("tf_count")
-                                    or row_dataset.get("tfCount")
-                                    or 0
-                                ),
+                                "tf_count": int(row_dataset.get("tf_count") or 0),
                             },
                             "colDataset": {
                                 "id": col_id,
-                                "dbName": col_db,
+                                "db_name": col_db,
                                 "type": col_dataset.get("type", "Expression"),
                                 "name": col_dataset.get("name", col_db),
-                                "tfCount": int(
-                                    col_dataset.get("tf_count")
-                                    or col_dataset.get("tfCount")
-                                    or 0
-                                ),
-                                "tf_count": int(
-                                    col_dataset.get("tf_count")
-                                    or col_dataset.get("tfCount")
-                                    or 0
-                                ),
+                                "tf_count": int(col_dataset.get("tf_count") or 0),
                             },
                             "intersectionCount": int(value),
                         }
@@ -221,7 +203,7 @@ def selection_matrix_server(
         ]
 
         for dataset in active:
-            db_name = str(dataset.get("db_name") or dataset.get("dbName"))
+            db_name = str(dataset.get("db_name"))
             tf_count = int(diagonal_tf_map.get(db_name, 0))
             header_cells.append(
                 ui.tags.th(
@@ -237,7 +219,7 @@ def selection_matrix_server(
         body_rows: list[ui.Tag] = []
         for row_index, row_dataset in enumerate(active):
             row_name = str(row_dataset.get("name", "Dataset"))
-            row_db = str(row_dataset.get("db_name") or row_dataset.get("dbName"))
+            row_db = str(row_dataset.get("db_name"))
             row_id = str(row_dataset.get("id"))
 
             cells: list[ui.Tag] = [
@@ -248,7 +230,7 @@ def selection_matrix_server(
             ]
 
             for col_index, col_dataset in enumerate(active):
-                col_db = str(col_dataset.get("db_name") or col_dataset.get("dbName"))
+                col_db = str(col_dataset.get("db_name"))
                 col_id = str(col_dataset.get("id"))
 
                 if col_index < row_index:

--- a/tfbpshiny/modules/selection_sidebar.py
+++ b/tfbpshiny/modules/selection_sidebar.py
@@ -58,9 +58,9 @@ def selection_sidebar_server(
         filter_counts = _active_filter_counts()
 
         selected_tf_total = sum(
-            int(dataset.get("tf_count") or dataset.get("tfCount") or 0)
+            int(dataset.get("tf_count") or 0)
             for dataset in selected
-            if dataset.get("tf_count_known") or dataset.get("tfCountKnown")
+            if dataset.get("tf_count_known")
         )
         selected_filters_total = sum(
             filter_counts.get(str(dataset["id"]), 0) for dataset in selected
@@ -162,18 +162,12 @@ def selection_sidebar_server(
             dataset_id = str(dataset["id"])
             toggle_id = _dataset_input_id("ds_toggle", dataset_id)
             configure_id = _dataset_input_id("configure", dataset_id)
-            badge = str(dataset.get("type_badge") or dataset.get("typeBadge") or "EX")
+            badge = str(dataset.get("type_badge") or "EX")
             badge_cls = f"badge badge-{badge.lower()}"
 
-            sample_count = int(
-                dataset.get("sample_count") or dataset.get("sampleCount") or 0
-            )
-            column_count = int(
-                dataset.get("column_count") or dataset.get("columnCount") or 0
-            )
-            sample_known = bool(
-                dataset.get("sample_count_known") or dataset.get("sampleCountKnown")
-            )
+            sample_count = int(dataset.get("sample_count") or 0)
+            column_count = int(dataset.get("column_count") or 0)
+            sample_known = bool(dataset.get("sample_count_known"))
             summary_text = (
                 f"{sample_count:,} rows · {column_count:,} cols"
                 if sample_known


### PR DESCRIPTION
Standardize on snake_case only since the codebase is pure Python/Shiny with no JS frontend consuming these keys.