### PR TITLE
refactor: replace per-selection VDB cache with lazy singleton

### DIFF
--- a/tfbpshiny/app.py
+++ b/tfbpshiny/app.py
@@ -11,7 +11,6 @@ from typing import Any, Literal, cast
 
 from dotenv import load_dotenv
 from shiny import App, reactive, render, ui
-from tfbpapi import VirtualDB
 
 from configure_logger import configure_logger
 from tfbpshiny.data_service import (
@@ -19,7 +18,6 @@ from tfbpshiny.data_service import (
     get_datasets,
     get_filter_options,
     get_intersection_cells,
-    get_or_create_vdb,
     get_row_count,
     get_sample_count,
 )
@@ -96,35 +94,6 @@ app_ui = ui.page_fillable(
 )
 
 # ---------------------------------------------------------------------------
-# Initialize VirtualDB
-# ---------------------------------------------------------------------------
-
-# note that for testing purposes in development, or quick updates in production,
-# you can use the .env to direct tfbpshiny to an alternate YAML config
-# with env var `VDB_CONFIG_PATH=/path/to/alternate.yaml`
-_default_config = Path(__file__).parent / "brentlab_yeast_collection.yaml"
-config = os.getenv("VDB_CONFIG_PATH", str(_default_config))
-logger.info("VDB config path: %s", config)
-vdb = VirtualDB(config)
-# this will create the default views
-logger.info("VDB initialized with tables: %s", vdb.tables())
-
-# datasets has the structure {data_type:
-#                               {
-#                                 assay1: [db_name1, db_name2, ...],
-#                                 assay2: [db_name3, ...]
-#                               }
-#                             }
-# eg {'Binding': {"Calling Cards": ['2026 Calling cards'],
-#                 "ChIP-chip": ['2004 Harbison']},
-#     'Perturbation': {"Overexpression": ['2020 Hackett'], "TFKO": ['2014 Kemmeren']}}
-datasets: dict[str, dict[str, list]] = {}
-for db_name in vdb.get_datasets():
-    datatype = vdb.get_tags(db_name).get("data_type", "Unknown")
-    assay = vdb.get_tags(db_name).get("assay", "Unknown")
-    datasets.setdefault(datatype, {}).setdefault(assay, []).append(db_name)
-
-# ---------------------------------------------------------------------------
 # Server
 # ---------------------------------------------------------------------------
 
@@ -142,9 +111,12 @@ def app_server(
     # updated in: nav_server (on nav click), _emit_navigation_intent_from_modal
     active_module: reactive.Value[str] = reactive.value("selection")
 
-    # values: list of dataset dicts with id, db_name, type, selected, tf_count, sample_count, etc.
-    # read by: selection_sidebar_server, selection_matrix_server, analysis_sidebar_server, analysis_workspace_server
-    # updated in: initialization, _set_dataset_selected, _handle_refresh_intersection
+    # values: list of dataset dicts with id, db_name, type, selected,
+    #   tf_count, sample_count, etc.
+    # read by: selection_sidebar_server, selection_matrix_server,
+    #   analysis_sidebar_server, analysis_workspace_server
+    # updated in: initialization, _set_dataset_selected,
+    #   _handle_refresh_intersection
     datasets: reactive.Value[list[dict[str, Any]]] = reactive.value([])
     # values: bool
     # read by: selection_sidebar_server
@@ -194,12 +166,18 @@ def app_server(
     last_selection_signature: reactive.Value[str | None] = reactive.value(None)
 
     # values: dataset_id string when config modal is open, else None
-    # read by: modal_layer, _sync_modal_include_toggle, _apply_config_modal_filters, _clear_config_modal_draft
-    # updated in: _handle_open_config, _close_config_modal_from_header, _close_config_modal_from_cancel, _apply_config_modal_filters
+    # read by: modal_layer, _sync_modal_include_toggle,
+    #   _apply_config_modal_filters, _clear_config_modal_draft
+    # updated in: _handle_open_config, _close_config_modal_from_header,
+    #   _close_config_modal_from_cancel, _apply_config_modal_filters
     active_config_dataset_id: reactive.Value[str | None] = reactive.value(None)
-    # values: intersection cell payload {rowDataset, colDataset, intersectionCount}, or None
+    # values: intersection cell payload
+    #   {rowDataset, colDataset, intersectionCount}, or None
     # read by: modal_layer, _emit_navigation_intent_from_modal
-    # updated in: _handle_matrix_cell_click, _close_intersection_modal_from_header, _close_intersection_modal_from_footer, _emit_navigation_intent_from_modal
+    # updated in: _handle_matrix_cell_click,
+    #   _close_intersection_modal_from_header,
+    #   _close_intersection_modal_from_footer,
+    #   _emit_navigation_intent_from_modal
     intersection_detail: reactive.Value[dict[str, Any] | None] = reactive.value(None)
     # values: navigation payload {rowDataset, colDataset, intersectionCount}, or None
     # read by: (currently unused downstream)
@@ -214,10 +192,14 @@ def app_server(
     #   comparison_mode: bool
     #   correlation_value_column: string
     #   page: integer, page_size: integer
-    #   composite_method: string, composite_filter_threshold: float, composite_filter_operator: string
-    #   composite_binding_datasets, composite_perturbation_datasets: list of db name strings
+    #   composite_method: string,
+    #   composite_filter_threshold: float,
+    #   composite_filter_operator: string
+    #   composite_binding_datasets,
+    #   composite_perturbation_datasets: list of db name strings
     # read by: analysis_sidebar_server, analysis_workspace_server
-    # updated in: analysis_sidebar_server (control inputs), _emit_navigation_intent_from_modal
+    # updated in: analysis_sidebar_server (control inputs),
+    #   _emit_navigation_intent_from_modal
     analysis_config: reactive.Value[dict[str, Any]] = reactive.value(
         {
             "view": "summary",
@@ -235,15 +217,14 @@ def app_server(
         }
     )
 
-    # # -- Initialization --
-    # try:
-    #     datasets.set(get_datasets())
-    #     datasets_error.set(None)
-    # except Exception as error:
-    #     datasets.set([])
-    #     datasets_error.set(str(error))
-    # finally:
-    #     datasets_loading.set(False)
+    # -- Initialization --
+    try:
+        datasets.set(get_datasets())
+    except Exception as error:
+        logger.warning("Failed to load datasets on startup: %s", error)
+        datasets.set([])
+    finally:
+        datasets_loading.set(False)
 
     # -- Internal helpers --
     def _dataset_by_id(dataset_id: str) -> dict[str, Any] | None:
@@ -280,7 +261,8 @@ def app_server(
         if changed:
             datasets.set(list(current))
 
-    # called in: _selected_filter_payloads, _selection_signature, _ensure_dataset_filter_options, _handle_refresh_intersection
+    # called in: _selected_filter_payloads, _selection_signature,
+    #   _ensure_dataset_filter_options, _handle_refresh_intersection
     @reactive.calc
     def _selected_datasets() -> list[dict[str, Any]]:
         """
@@ -389,20 +371,14 @@ def app_server(
             if not dataset:
                 raise ValueError("Dataset no longer available")
 
-            # Build a VirtualDB containing at least this dataset.
-            selected = _selected_datasets()
-            selected_db_names = [str(e.get("db_name")) for e in selected]
             ds_db_name = str(dataset.get("db_name"))
-            all_db_names = sorted(set(selected_db_names + [ds_db_name]))
-            vdb = get_or_create_vdb(all_db_names)
-
             metadata_configs = dataset.get("metadata_configs") or []
             if metadata_configs:
                 meta_table = str(metadata_configs[0].get("db_name"))
             else:
                 meta_table = f"{ds_db_name}_meta"
 
-            options = get_filter_options(meta_table, vdb)
+            options = get_filter_options(meta_table)
         except Exception as error:
             logger.warning(
                 "Failed to load filter options for %s: %s", dataset_id, error
@@ -455,8 +431,6 @@ def app_server(
         intersection_error.set(None)
 
         try:
-            vdb = get_or_create_vdb(selected_db_names)
-
             sample_counts: dict[str, int | None] = {}
             column_counts: dict[str, int | None] = {}
             for entry in selected:
@@ -467,10 +441,10 @@ def app_server(
                     # For binding datasets, count distinct samples.
                     # For perturbation datasets, each row is a sample.
                     if dataset_type == "Binding":
-                        sample_counts[dataset_id] = int(get_sample_count(db_name, vdb))
+                        sample_counts[dataset_id] = int(get_sample_count(db_name))
                     else:
-                        sample_counts[dataset_id] = int(get_row_count(db_name, vdb))
-                    column_counts[dataset_id] = int(get_column_count(db_name, vdb))
+                        sample_counts[dataset_id] = int(get_row_count(db_name))
+                    column_counts[dataset_id] = int(get_column_count(db_name))
                 except Exception:
                     sample_counts[dataset_id] = None
                     column_counts[dataset_id] = None
@@ -494,7 +468,6 @@ def app_server(
             payloads = _selected_filter_payloads()
             cells = get_intersection_cells(
                 selected_db_names,
-                vdb,
                 filters=payloads["categorical"],
                 numeric_filters=payloads["numeric"],
             )
@@ -534,7 +507,8 @@ def app_server(
         """
         Store the clicked intersection cell payload to open the detail modal.
 
-        :param payload: dict with ``rowDataset``, ``colDataset``, and ``intersectionCount``
+        :param payload: dict with ``rowDataset``, ``colDataset``,
+            and ``intersectionCount``
 
         """
         intersection_detail.set(payload)

--- a/tfbpshiny/data_service.py
+++ b/tfbpshiny/data_service.py
@@ -10,16 +10,14 @@ from __future__ import annotations
 
 import logging
 import math
-import os
 import re
 import statistics
-import tempfile
-import threading
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
-from tfbpapi import VirtualDB
+from tfbpapi import MetadataConfig, VirtualDB
+
+from tfbpshiny.vdb import get_vdb
 
 logger = logging.getLogger("shiny")
 
@@ -43,12 +41,44 @@ def _dataset_group_and_badge(dataset_type: str) -> tuple[str, str]:
         return ("perturbation", "PR")
     if dataset_type == "Comparative":
         return ("comparative", "CO")
-    raise ValueError(f"Unknown dataset type: {dataset_type}")
+    logger.warning("Unknown dataset type: %s", dataset_type)
+    return ("unknown", "UK")
 
 
 def _title_case(raw: str) -> str:
     parts = re.sub(r"[_-]+", " ", raw).strip()
     return re.sub(r"\b\w", lambda m: m.group(0).upper(), parts)
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _validate_identifier(name: str) -> str:
+    """Validate that *name* is a safe SQL identifier (alphanumeric + underscore)."""
+    if not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"Unsafe SQL identifier: {name!r}")
+    return name
+
+
+def _infer_dataset_type(repo_id: str, config_name: str, ds_cfg: Any) -> str:
+    """Infer dataset type from tags or config fields."""
+    tags = getattr(ds_cfg, "tags", None) or {}
+    if isinstance(tags, dict):
+        data_type = tags.get("data_type", "")
+        if data_type:
+            return str(data_type)
+
+    if getattr(ds_cfg, "links", None):
+        return "Comparative"
+
+    # Heuristic fallback based on config name or repo id.
+    lower = (config_name + " " + repo_id).lower()
+    if "binding" in lower or "chip" in lower or "calling" in lower:
+        return "Binding"
+    if "perturbation" in lower or "expression" in lower or "tfko" in lower:
+        return "Perturbation"
+
+    return "Binding"
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +94,7 @@ def get_datasets(yaml_path: Path | str | None = None) -> list[dict[str, Any]]:
 
     """
     path = Path(yaml_path) if yaml_path else _YAML_PATH
+    config = MetadataConfig.from_yaml(path)
 
     enriched: list[dict[str, Any]] = []
     for repo_id, repo_cfg in config.repositories.items():
@@ -144,99 +175,7 @@ def get_datasets(yaml_path: Path | str | None = None) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
-# 2. get_or_create_vdb  (replaces sync_mock_active_set_config)
-# ---------------------------------------------------------------------------
-
-_vdb_cache: dict[str, VirtualDB] = {}
-_vdb_cache_key: str | None = None
-_vdb_lock = threading.Lock()
-
-
-def _get_hf_token() -> str | None:
-    return os.environ.get("HF_TOKEN")
-
-
-def _build_subset_config(
-    full_config: MetadataConfig,
-    selected_db_names: set[str],
-) -> Path:
-    """Write a subset YAML config containing only the selected datasets."""
-    raw = yaml.safe_load(_YAML_PATH.read_text())
-
-    subset_repos: dict[str, Any] = {}
-    for repo_id, repo_cfg in full_config.repositories.items():
-        if not repo_cfg.dataset:
-            continue
-
-        matched_datasets: dict[str, Any] = {}
-        for config_name, ds_cfg in repo_cfg.dataset.items():
-            db_name = ds_cfg.db_name or config_name
-            if db_name in selected_db_names:
-                # Pull the original YAML dict for this dataset to avoid
-                # needing to reverse-serialize pydantic models.
-                orig_repo = raw.get("repositories", {}).get(repo_id, {})
-                orig_ds = orig_repo.get("dataset", {}).get(config_name, {})
-                if orig_ds:
-                    matched_datasets[config_name] = orig_ds
-
-        if matched_datasets:
-            # Include repo-level properties (everything except 'dataset').
-            orig_repo = raw.get("repositories", {}).get(repo_id, {})
-            repo_entry: dict[str, Any] = {
-                k: v for k, v in orig_repo.items() if k != "dataset"
-            }
-            repo_entry["dataset"] = matched_datasets
-            subset_repos[repo_id] = repo_entry
-
-    subset: dict[str, Any] = {"repositories": subset_repos}
-    if "factor_aliases" in raw:
-        subset["factor_aliases"] = raw["factor_aliases"]
-    if "missing_value_labels" in raw:
-        subset["missing_value_labels"] = raw["missing_value_labels"]
-    if "description" in raw:
-        subset["description"] = raw["description"]
-
-    tmp = tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".yaml",
-        prefix="tfbpshiny_subset_",
-        delete=False,
-    )
-    yaml.safe_dump(subset, tmp, default_flow_style=False)
-    tmp.close()
-    return Path(tmp.name)
-
-
-def get_or_create_vdb(
-    selected_db_names: list[str],
-    token: str | None = None,
-) -> VirtualDB:
-    """Return a VirtualDB for the selected datasets, cached by selection set."""
-    global _vdb_cache_key
-
-    cache_key = ",".join(sorted(selected_db_names))
-    with _vdb_lock:
-        if cache_key == _vdb_cache_key and cache_key in _vdb_cache:
-            return _vdb_cache[cache_key]
-
-        full_config = MetadataConfig.from_yaml(_YAML_PATH)
-        subset_path = _build_subset_config(full_config, set(selected_db_names))
-        hf_token = token or _get_hf_token()
-
-        try:
-            vdb = VirtualDB(config_path=subset_path, token=hf_token, lazy=True)
-        finally:
-            subset_path.unlink(missing_ok=True)
-
-        _vdb_cache.clear()
-        _vdb_cache[cache_key] = vdb
-        _vdb_cache_key = cache_key
-
-        return vdb
-
-
-# ---------------------------------------------------------------------------
-# 3. get_filter_options  (replaces get_mock_filter_options)
+# 2. get_filter_options  (replaces get_mock_filter_options)
 # ---------------------------------------------------------------------------
 
 _NUMERIC_TYPE_PATTERN = re.compile(
@@ -247,9 +186,10 @@ _NUMERIC_TYPE_PATTERN = re.compile(
 
 def get_filter_options(
     meta_table: str,
-    vdb: VirtualDB,
+    vdb: VirtualDB | None = None,
 ) -> list[dict[str, Any]]:
     """Discover filter fields from a metadata table via VirtualDB.describe()."""
+    vdb = vdb or get_vdb()
     safe_table = _validate_identifier(meta_table)
     try:
         desc_df = vdb.describe(safe_table)
@@ -279,7 +219,7 @@ def get_filter_options(
                 min_val = float(stats["mn"].iloc[0]) if len(stats) else 0.0
                 max_val = float(stats["mx"].iloc[0]) if len(stats) else 0.0
             except Exception:
-                logger.debug(
+                logger.warning(
                     "Failed to get min/max for %s.%s",
                     safe_table,
                     safe_col,
@@ -303,7 +243,7 @@ def get_filter_options(
                 )
                 values = sorted(str(v) for v in vals_df[col_name].tolist())
             except Exception:
-                logger.debug(
+                logger.warning(
                     "Failed to get distinct values for %s.%s",
                     safe_table,
                     safe_col,
@@ -327,14 +267,15 @@ def get_filter_options(
 # ---------------------------------------------------------------------------
 
 
-def get_row_count(db_name: str, vdb: VirtualDB) -> int:
+def get_row_count(db_name: str, vdb: VirtualDB | None = None) -> int:
     """Return the measurement count for a dataset's metadata table."""
+    vdb = vdb or get_vdb()
     safe_table = _validate_identifier(f"{db_name}_meta")
     result = vdb.query(f"SELECT COUNT(*) AS cnt FROM {safe_table}")
     return int(result["cnt"].iloc[0]) if len(result) else 0
 
 
-def get_sample_count(db_name: str, vdb: VirtualDB) -> int:
+def get_sample_count(db_name: str, vdb: VirtualDB | None = None) -> int:
     """
     Return the sample count (distinct sample_id) for a dataset.
 
@@ -342,15 +283,22 @@ def get_sample_count(db_name: str, vdb: VirtualDB) -> int:
     unique sample count instead of measurement count.
 
     """
+    vdb = vdb or get_vdb()
     safe_table = _validate_identifier(f"{db_name}_meta")
-    # Use the resolved sample_id column name from VirtualDB config
-    sample_col = vdb._get_sample_id_col(db_name)
+    # Use the resolved sample_id column name from VirtualDB config.
+    # _get_sample_id_col is private but has no public equivalent; fall back to
+    # "sample_id" if the method is removed in a future tfbpapi release.
+    try:
+        sample_col = _validate_identifier(vdb._get_sample_id_col(db_name))
+    except (AttributeError, ValueError):
+        sample_col = "sample_id"
     result = vdb.query(f"SELECT COUNT(DISTINCT {sample_col}) AS cnt FROM {safe_table}")
     return int(result["cnt"].iloc[0]) if len(result) else 0
 
 
-def get_column_count(db_name: str, vdb: VirtualDB) -> int:
+def get_column_count(db_name: str, vdb: VirtualDB | None = None) -> int:
     """Return the column count for a dataset's metadata table."""
+    vdb = vdb or get_vdb()
     safe_table = _validate_identifier(f"{db_name}_meta")
     try:
         desc_df = vdb.describe(safe_table)
@@ -431,11 +379,12 @@ def _build_where_clause(
 
 def get_intersection_cells(
     db_names: list[str],
-    vdb: VirtualDB,
+    vdb: VirtualDB | None = None,
     filters: dict[str, Any] | None = None,
     numeric_filters: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Compute pairwise TF set intersections across selected datasets."""
+    vdb = vdb or get_vdb()
     filters = filters or {}
     numeric_filters = numeric_filters or {}
 
@@ -539,7 +488,7 @@ def get_dto_config(yaml_path: Path | str | None = None) -> dict[str, list[str]]:
 def get_dto_data(
     binding_dbs: list[str],
     perturbation_dbs: list[str],
-    vdb: VirtualDB,
+    vdb: VirtualDB | None = None,
 ) -> list[dict[str, Any]]:
     """
     Query DTO data for the selected binding and perturbation datasets.
@@ -551,12 +500,13 @@ def get_dto_data(
     Args:
         binding_dbs: List of binding dataset db_names to filter
         perturbation_dbs: List of perturbation dataset db_names to filter
-        vdb: VirtualDB instance with DTO dataset loaded
+        vdb: VirtualDB instance (defaults to global singleton)
 
     Returns:
         List of dicts with binding_id, perturbation_id, dto_pvalue, and dto_fdr
 
     """
+    vdb = vdb or get_vdb()
     # Check if dto_expanded view exists
     try:
         fields = set(vdb.get_fields("dto_expanded"))
@@ -666,7 +616,7 @@ def _pearson_correlation(x: list[float], y: list[float]) -> float | None:
 def get_median_correlation_matrix(
     db_names: list[str],
     value_column: str,
-    vdb: VirtualDB,
+    vdb: VirtualDB | None = None,
 ) -> dict[str, Any]:
     """
     Compute a median-of-per-TF-correlations matrix across datasets.
@@ -677,6 +627,7 @@ def get_median_correlation_matrix(
     3. The cell value is the median of the per-TF correlations.
 
     """
+    vdb = vdb or get_vdb()
     safe_value_col = _validate_identifier(value_column)
 
     # --- gather per-dataset data: {db_name: {tf: {target: value}}} ---
@@ -813,7 +764,7 @@ _STRUCTURAL_COLUMNS = frozenset(
 
 def get_shared_numeric_columns(
     db_names: list[str],
-    vdb: VirtualDB,
+    vdb: VirtualDB | None = None,
 ) -> list[str]:
     """
     Return sorted numeric columns available across datasets' meta tables.
@@ -828,6 +779,7 @@ def get_shared_numeric_columns(
     Excludes structural columns (identifiers) that aren't analysis values.
 
     """
+    vdb = vdb or get_vdb()
     if not db_names:
         return []
 

--- a/tfbpshiny/modules/analysis_sidebar.py
+++ b/tfbpshiny/modules/analysis_sidebar.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from shiny import module, reactive, render, ui
 
 from tfbpshiny.data_service import (
     get_dto_config,
-    get_or_create_vdb,
     get_shared_numeric_columns,
 )
 from tfbpshiny.utils.source_name_lookup import get_source_name_dict
+
+logger = logging.getLogger("shiny")
 
 _MODULE_LABELS: dict[str, str] = {
     "binding": "Binding Analysis",
@@ -262,12 +264,11 @@ def analysis_sidebar_server(
         ]
 
     @reactive.calc
-    def _vdb_for_module() -> tuple[Any, list[str]] | None:
+    def _numeric_columns_for_module() -> list[str] | None:
         """
-        Cache VDB and numeric columns for current module's datasets.
+        Cache numeric columns for current module's datasets.
 
-        Memoized by the sorted db_names of relevant datasets. This prevents duplicate
-        expensive VDB creation when switching modules.
+        Memoized by the sorted db_names of relevant datasets.
 
         """
         relevant = _relevant_datasets()
@@ -278,10 +279,9 @@ def analysis_sidebar_server(
             return None
 
         try:
-            vdb = get_or_create_vdb(db_names)
-            columns = get_shared_numeric_columns(db_names, vdb)
-            return (vdb, columns)
-        except Exception:
+            return get_shared_numeric_columns(db_names)
+        except Exception as e:
+            logger.warning("Failed to get shared numeric columns: %s", e)
             return None
 
     def _set_config_if_changed(next_config: dict[str, Any]) -> None:
@@ -387,15 +387,13 @@ def analysis_sidebar_server(
                 "Need 2+ datasets for correlation.",
             )
 
-        # Use cached VDB and columns from _vdb_for_module().
-        cached = _vdb_for_module()
-        if cached is None:
+        # Use cached columns from _numeric_columns_for_module().
+        columns = _numeric_columns_for_module()
+        if columns is None:
             return ui.p(
                 {"style": "font-size:12px; color:var(--color-text-muted);"},
                 "Unable to load column metadata. Check connection.",
             )
-
-        _, columns = cached
 
         if not columns:
             return ui.p(

--- a/tfbpshiny/modules/analysis_workspace.py
+++ b/tfbpshiny/modules/analysis_workspace.py
@@ -12,7 +12,6 @@ from shiny import module, reactive, render, ui
 from tfbpshiny.data_service import (
     get_dto_data,
     get_median_correlation_matrix,
-    get_or_create_vdb,
 )
 from tfbpshiny.mock_data import get_mock_source_summary
 from tfbpshiny.utils.create_distribution_plot import create_distribution_plot
@@ -109,18 +108,17 @@ def analysis_workspace_server(
         return selected_db, comparison_db, comparison_mode
 
     @reactive.calc
-    def _vdb_for_correlation() -> tuple[Any, dict[str, Any]] | None:
+    def _correlation_result() -> dict[str, Any] | None:
         """
-        Cache VDB and correlation result for current correlation view.
+        Cache correlation result for current correlation view.
 
-        Memoized by the relevant datasets and value column. This prevents duplicate
-        expensive VDB creation when switching views or modules.
+        Memoized by the relevant datasets and value column.
 
         """
         config = analysis_config()
         view = str(config.get("view", ""))
 
-        # Only create VDB when in correlation view.
+        # Only compute when in correlation view.
         if view != "correlation":
             return None
 
@@ -135,10 +133,9 @@ def analysis_workspace_server(
             return None
 
         try:
-            vdb = get_or_create_vdb(db_names)
-            result = get_median_correlation_matrix(db_names, value_column, vdb)
-            return (vdb, result)
-        except Exception:
+            return get_median_correlation_matrix(db_names, value_column)
+        except Exception as e:
+            logger.warning("Failed to compute correlation matrix: %s", e)
             return None
 
     @render.ui
@@ -186,9 +183,9 @@ def analysis_workspace_server(
             return _render_summary(selected_db)
 
         if view == "correlation":
-            # Use cached VDB and correlation result.
-            cached = _vdb_for_correlation()
-            if cached is None:
+            # Use cached correlation result.
+            result = _correlation_result()
+            if result is None:
                 return ui.div(
                     {"class": "empty-state"},
                     ui.h3("Correlation data unavailable"),
@@ -196,7 +193,6 @@ def analysis_workspace_server(
                         "Select a valid value column present in at least two datasets."
                     ),
                 )
-            _, result = cached
             value_column = str(config.get("correlation_value_column", ""))
             return _render_correlation_from_result(result, value_column)
 
@@ -253,9 +249,7 @@ def _render_composite(
     # Query DTO data from VirtualDB
     df = pd.DataFrame()
     try:
-        all_db_names = bd_names + pr_names + ["dto"]
-        vdb = get_or_create_vdb(all_db_names)
-        raw = get_dto_data(bd_names, pr_names, vdb)
+        raw = get_dto_data(bd_names, pr_names)
 
         if raw:
             df = pd.DataFrame(raw)
@@ -545,8 +539,7 @@ def _render_correlation_matrix(
         )
 
     try:
-        vdb = get_or_create_vdb(db_names)
-        result = get_median_correlation_matrix(db_names, value_column, vdb)
+        result = get_median_correlation_matrix(db_names, value_column)
     except Exception as e:
         return ui.div(
             {"class": "empty-state"},

--- a/tfbpshiny/vdb.py
+++ b/tfbpshiny/vdb.py
@@ -1,0 +1,29 @@
+"""Lazy VDB singleton — one global VirtualDB with all data preloaded."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+
+from tfbpapi import VirtualDB
+
+logger = logging.getLogger("shiny")
+_DEFAULT_CONFIG = Path(__file__).parent / "brentlab_yeast_collection.yaml"
+
+_vdb: VirtualDB | None = None
+_vdb_lock = threading.Lock()
+
+
+def get_vdb() -> VirtualDB:
+    """Return the shared VirtualDB instance, creating lazily on first call."""
+    global _vdb
+    if _vdb is None:
+        with _vdb_lock:
+            if _vdb is None:
+                config_path = os.getenv("VDB_CONFIG_PATH", str(_DEFAULT_CONFIG))
+                logger.info("VDB config path: %s", config_path)
+                _vdb = VirtualDB(config_path)
+                logger.info("VDB initialized with tables: %s", _vdb.tables())
+    return _vdb


### PR DESCRIPTION
All data_service functions now default to a global VirtualDB singleton (vdb.py), removing get_or_create_vdb and subset YAML generation.