### PR TITLE
diag modal now shows info on sample to regulator multiplicity

### DIFF
--- a/tests/unit/test_select_datasets.py
+++ b/tests/unit/test_select_datasets.py
@@ -3,6 +3,7 @@
 from tfbpshiny.modules.select_datasets.queries import (
     _build_where,
     metadata_query,
+    regulator_breakdown_query,
     regulator_locus_tags_query,
     sample_count_query,
 )
@@ -37,7 +38,7 @@ def test_build_where_categorical():
     where = _build_where(
         {"strain": {"type": "categorical", "value": ["BY4741"]}}, params
     )
-    assert "strain IN" in where
+    assert '"strain" IN' in where
     assert "BY4741" in params.values()
 
 
@@ -89,3 +90,42 @@ def test_regulator_locus_tags_query():
     sql, params = regulator_locus_tags_query("harbison")
     assert "DISTINCT regulator_locus_tag" in sql
     assert params == {}
+
+
+# --- regulator_breakdown_query ---
+
+
+def test_regulator_breakdown_query_no_filters_no_cols():
+    sql, params = regulator_breakdown_query("harbison", [])
+    assert "n_multi" in sql
+    assert "harbison_meta" in sql
+    assert "HAVING COUNT(*) > 1" in sql
+    assert params == {}
+
+
+def test_regulator_breakdown_query_candidate_cols_in_select():
+    sql, params = regulator_breakdown_query(
+        "harbison", ["Carbon source", "Temperature"]
+    )
+    assert 'COUNT(DISTINCT "Carbon source")' in sql
+    assert 'COUNT(DISTINCT "Temperature")' in sql
+    assert params == {}
+
+
+def test_regulator_breakdown_query_with_filters():
+    sql, params = regulator_breakdown_query(
+        "harbison",
+        ["Carbon source"],
+        {"strain": {"type": "categorical", "value": ["BY4741"]}},
+    )
+    assert "BY4741" in params.values()
+    assert 'COUNT(DISTINCT "Carbon source")' in sql
+    # filters produce WHERE; the regulator IN clause must use AND, not a second WHERE
+    assert "AND regulator_locus_tag IN" in sql
+    assert sql.count("WHERE") == 3  # filters appear in both multi and per_reg CTEs
+
+
+def test_regulator_breakdown_query_no_filters_uses_where():
+    sql, params = regulator_breakdown_query("harbison", ["Carbon source"])
+    # no filters — regulator IN clause must open with WHERE, not AND
+    assert "WHERE regulator_locus_tag IN" in sql

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -130,9 +130,54 @@ def regulator_locus_tags_query(
     )
 
 
+def regulator_breakdown_query(
+    db_name: str,
+    candidate_cols: list[str],
+    filters: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Return ``(sql, params)`` for a single query that counts multi-sample regulators and
+    distinct values per candidate column in one pass.
+
+    The result is a single row with:
+
+    - ``n_multi`` — number of regulators that appear in more than one sample
+    - One column per entry in ``candidate_cols`` — the number of distinct
+      values for that column across multi-sample regulators only
+
+    If ``n_multi`` is 0 every regulator maps to exactly one sample (uniform).
+    Otherwise, candidate columns where the count is > 1 are the differentiating
+    columns.
+
+    :param db_name: Dataset name.
+    :param candidate_cols: Columns to check, pre-filtered to exclude identity
+        and hidden fields.
+    :param filters: Active filters for this dataset.
+    :return: ``(sql_string, params_dict)``.
+
+    """
+    params: dict[str, Any] = {}
+    where = _build_where(filters, params)
+    count_exprs = ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in candidate_cols)
+    sql = (
+        f"WITH multi AS ("
+        f"  SELECT regulator_locus_tag"
+        f"  FROM {db_name}_meta{where}"
+        f"  GROUP BY regulator_locus_tag"
+        f"  HAVING COUNT(*) > 1"
+        f") "
+        f"SELECT COUNT(*) AS n_multi"
+        + (f", {count_exprs}" if count_exprs else "")
+        + f" FROM {db_name}_meta{where}"
+        f" WHERE regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+    )
+    return sql, params
+
+
 __all__ = [
     "FIELD_TYPE_OVERRIDES",
     "metadata_query",
     "sample_count_query",
     "regulator_locus_tags_query",
+    "regulator_breakdown_query",
 ]

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -158,18 +158,29 @@ def regulator_breakdown_query(
     """
     params: dict[str, Any] = {}
     where = _build_where(filters, params)
-    count_exprs = ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in candidate_cols)
+    # per_reg: for each multi-sample regulator, count distinct values per column
+    per_reg_exprs = ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in candidate_cols)
+    # agg: count how many regulators show internal variation (per-regulator distinct > 1)
+    agg_exprs = ", ".join(
+        f'COUNT(*) FILTER (WHERE "{c}" > 1) AS "{c}"' for c in candidate_cols
+    )
     sql = (
         f"WITH multi AS ("
         f"  SELECT regulator_locus_tag"
         f"  FROM {db_name}_meta{where}"
         f"  GROUP BY regulator_locus_tag"
         f"  HAVING COUNT(*) > 1"
+        f"), per_reg AS ("
+        f"  SELECT regulator_locus_tag"
+        + (f", {per_reg_exprs}" if per_reg_exprs else "")
+        + f"  FROM {db_name}_meta{where}"
+        + (" AND" if where else " WHERE")
+        + f" regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+        f"  GROUP BY regulator_locus_tag"
         f") "
         f"SELECT COUNT(*) AS n_multi"
-        + (f", {count_exprs}" if count_exprs else "")
-        + f" FROM {db_name}_meta{where}"
-        f" WHERE regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+        + (f", {agg_exprs}" if agg_exprs else "")
+        + f" FROM per_reg"
     )
     return sql, params
 

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -102,7 +102,7 @@ def select_datasets_workspace_server(
         """
         Create the modal and contents on click of a diagonal cell.
 
-        The modal text will describe whether there is a 1-1 correspondance between
+        The modal text will describe whether there is a 1-1 correspondence between
         regulators and samples. If there are not, then it will list the metadata columns
         that differentiate samples with the same regulator.
 

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -9,9 +9,11 @@ from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
 from tfbpshiny.modules.select_datasets.queries import (
+    regulator_breakdown_query,
     regulator_locus_tags_query,
     sample_count_query,
 )
+from tfbpshiny.modules.select_datasets.server.sidebar import HIDDEN_FILTER_FIELDS
 from tfbpshiny.modules.select_datasets.ui import (
     diagonal_cell_modal_ui,
     off_diagonal_cell_modal_ui,
@@ -97,13 +99,51 @@ def select_datasets_workspace_server(
         return {"diagonal": diagonal, "cross_dataset": cross_dataset}
 
     def _make_diagonal_effect(db_name: str) -> None:
-        """Register a per-dataset click effect for a diagonal cell button."""
+        """
+        Create the modal and contents on click of a diagonal cell.
+
+        The modal text will describe whether there is a 1-1 correspondance between
+        regulators and samples. If there are not, then it will list the metadata columns
+        that differentiate samples with the same regulator.
+
+        """
         btn_id = f"diag_{db_name}"
 
         @reactive.effect
         @reactive.event(input[btn_id])
         def _on_click() -> None:
-            ui.modal_show(diagonal_cell_modal_ui())
+            filters = dataset_filters().get(db_name)
+
+            all_cols = vdb.get_fields(f"{db_name}_meta")
+            # TODO: this is a good use case for the field `role` experimental
+            # condition -- only use experimental condition fields and remove
+            # any hidden filter fields
+            remove_cols = (
+                {"sample_id"}
+                | {c for c in all_cols if c.lower().startswith("regulator")}
+                | HIDDEN_FILTER_FIELDS.get("*", set())
+                | HIDDEN_FILTER_FIELDS.get(db_name, set())
+            )
+            candidate_cols = [c for c in all_cols if c not in remove_cols]
+
+            sql, params = regulator_breakdown_query(db_name, candidate_cols, filters)
+            row = vdb.query(sql, **params).iloc[0]
+            n_multi = int(row["n_multi"])
+
+            if n_multi == 0:
+                multi_regulator_sample_breakdown: dict = {"uniform": True}
+            else:
+                diff_cols = [c for c in candidate_cols if row[c] > 1]
+                multi_regulator_sample_breakdown = {
+                    "uniform": False,
+                    "n_multi": n_multi,
+                    "differentiating_columns": diff_cols,
+                }
+
+            display_name = display_names.get(db_name, db_name)
+            ui.modal_show(
+                diagonal_cell_modal_ui(display_name, multi_regulator_sample_breakdown)
+            )
 
     def _make_off_diagonal_effect(db_a: str, db_b: str) -> None:
         """Register per-pair click and modal-action effects for an off-diagonal cell."""

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -133,7 +133,7 @@ def select_datasets_workspace_server(
             if n_multi == 0:
                 multi_regulator_sample_breakdown: dict = {"uniform": True}
             else:
-                diff_cols = [c for c in candidate_cols if row[c] > 1]
+                diff_cols = [c for c in candidate_cols if row[c] > 0]
                 multi_regulator_sample_breakdown = {
                     "uniform": False,
                     "n_multi": n_multi,

--- a/tfbpshiny/modules/select_datasets/ui.py
+++ b/tfbpshiny/modules/select_datasets/ui.py
@@ -283,10 +283,39 @@ def selection_matrix_ui() -> ui.Tag:
     )
 
 
-def diagonal_cell_modal_ui() -> ui.Tag:
-    """Placeholder modal for diagonal (single-dataset) matrix cells."""
+def diagonal_cell_modal_ui(display_name: str, breakdown: dict) -> ui.Tag:
+    """
+    Modal for diagonal matrix cells summarising sample/regulator multiplicity.
+
+    This will either say that each sample interrogates a unique regulator,
+    or provide information about which columns differentiate samples that share
+    regulators.
+
+    :param display_name: Human-readable dataset name for the modal title.
+    :param breakdown: Dict produced by the multiplicity analysis in workspace.py.
+        ``{"uniform": True}`` when each regulator maps to exactly one sample;
+        ``{"uniform": False, "n_multi": int, "differentiating_columns": list[str]}``
+        otherwise.
+
+    """
+    if breakdown.get("uniform"):
+        body = ui.p("Each sample represents a unique interrogated regulator.")
+    else:
+        cols = breakdown.get("differentiating_columns", [])
+        body = ui.div(
+            ui.p(
+                f"{breakdown['n_multi']:,} regulators appear in multiple samples. "
+                f"Samples differ by:"
+            ),
+            (
+                ui.tags.ul(*[ui.tags.li(c) for c in cols])
+                if cols
+                else ui.p(ui.tags.em("unknown columns"))
+            ),
+        )
     return ui.modal(
-        ui.p("diagonal"),
+        body,
+        title=display_name,
         easy_close=True,
         footer=ui.modal_button("Close"),
     )


### PR DESCRIPTION
Rather than commenting out the diag modal, I added info on the columns that differentiate samples with the same regulator, when there is not a 1-1 correspondence between samples and regulators.

Closes #203 