### PR TITLE
Fix/non diag modal intersect filter

### DIFF
--- a/tests/unit/test_select_datasets.py
+++ b/tests/unit/test_select_datasets.py
@@ -3,6 +3,7 @@
 from tfbpshiny.modules.select_datasets.queries import (
     _build_where,
     metadata_query,
+    regulator_breakdown_query,
     regulator_locus_tags_query,
     sample_count_query,
 )
@@ -37,7 +38,7 @@ def test_build_where_categorical():
     where = _build_where(
         {"strain": {"type": "categorical", "value": ["BY4741"]}}, params
     )
-    assert "strain IN" in where
+    assert '"strain" IN' in where
     assert "BY4741" in params.values()
 
 
@@ -89,3 +90,42 @@ def test_regulator_locus_tags_query():
     sql, params = regulator_locus_tags_query("harbison")
     assert "DISTINCT regulator_locus_tag" in sql
     assert params == {}
+
+
+# --- regulator_breakdown_query ---
+
+
+def test_regulator_breakdown_query_no_filters_no_cols():
+    sql, params = regulator_breakdown_query("harbison", [])
+    assert "n_multi" in sql
+    assert "harbison_meta" in sql
+    assert "HAVING COUNT(*) > 1" in sql
+    assert params == {}
+
+
+def test_regulator_breakdown_query_candidate_cols_in_select():
+    sql, params = regulator_breakdown_query(
+        "harbison", ["Carbon source", "Temperature"]
+    )
+    assert 'COUNT(DISTINCT "Carbon source")' in sql
+    assert 'COUNT(DISTINCT "Temperature")' in sql
+    assert params == {}
+
+
+def test_regulator_breakdown_query_with_filters():
+    sql, params = regulator_breakdown_query(
+        "harbison",
+        ["Carbon source"],
+        {"strain": {"type": "categorical", "value": ["BY4741"]}},
+    )
+    assert "BY4741" in params.values()
+    assert 'COUNT(DISTINCT "Carbon source")' in sql
+    # filters produce WHERE; the regulator IN clause must use AND, not a second WHERE
+    assert "AND regulator_locus_tag IN" in sql
+    assert sql.count("WHERE") == 3  # filters appear in both multi and per_reg CTEs
+
+
+def test_regulator_breakdown_query_no_filters_uses_where():
+    sql, params = regulator_breakdown_query("harbison", ["Carbon source"])
+    # no filters — regulator IN clause must open with WHERE, not AND
+    assert "WHERE regulator_locus_tag IN" in sql

--- a/tests/unit/test_select_datasets.py
+++ b/tests/unit/test_select_datasets.py
@@ -4,6 +4,7 @@ from tfbpshiny.modules.select_datasets.queries import (
     _build_where,
     metadata_query,
     regulator_breakdown_query,
+    regulator_display_labels_query,
     regulator_locus_tags_query,
     sample_count_query,
 )
@@ -89,6 +90,14 @@ def test_sample_count_query_with_regulators():
 def test_regulator_locus_tags_query():
     sql, params = regulator_locus_tags_query("harbison")
     assert "DISTINCT regulator_locus_tag" in sql
+    assert params == {}
+
+
+def test_regulator_display_labels_query():
+    sql, params = regulator_display_labels_query("harbison")
+    assert "regulator_locus_tag" in sql
+    assert "regulator_symbol" in sql
+    assert "harbison_meta" in sql
     assert params == {}
 
 

--- a/tfbpshiny/app.css
+++ b/tfbpshiny/app.css
@@ -381,6 +381,18 @@ body {
     background: #4A5568;
 }
 
+.matrix-summary-table .matrix-cell-active {
+    background: #2B4C7E;
+}
+
+.matrix-summary-table .matrix-cell-active:hover {
+    background: #3A6098;
+}
+
+.matrix-summary-table .matrix-cell-active .matrix-cell-button {
+    color: #FFFFFF;
+}
+
 .matrix-cell-button {
     width: 100%;
     height: 100%;

--- a/tfbpshiny/app.py
+++ b/tfbpshiny/app.py
@@ -177,26 +177,60 @@ def app_server(input: Any, output: Any, session: Any) -> None:
     @reactive.effect
     @reactive.event(input.home, ignore_init=True)
     def _nav_home() -> None:
+        """
+        Switch the active module to the home page.
+
+        :trigger: ``input.home`` — fires when the user clicks the HOME nav button.
+
+        """
         active_module.set("home")
 
     @reactive.effect
     @reactive.event(input.selection, ignore_init=True)
     def _nav_selection() -> None:
+        """
+        Switch the active module to the dataset selection page.
+
+        :trigger: ``input.selection`` — fires when the user clicks the SELECT
+            DATASETS nav button.
+
+        """
         active_module.set("selection")
 
     @reactive.effect
     @reactive.event(input.binding, ignore_init=True)
     def _nav_binding() -> None:
+        """
+        Switch the active module to the binding data page.
+
+        :trigger: ``input.binding`` — fires when the user clicks the BINDING nav
+            button.
+
+        """
         active_module.set("binding")
 
     @reactive.effect
     @reactive.event(input.perturbation, ignore_init=True)
     def _nav_perturbation() -> None:
+        """
+        Switch the active module to the perturbation data page.
+
+        :trigger: ``input.perturbation`` — fires when the user clicks the
+            PERTURBATION nav button.
+
+        """
         active_module.set("perturbation")
 
     @reactive.effect
     @reactive.event(input.comparison, ignore_init=True)
     def _nav_comparison() -> None:
+        """
+        Switch the active module to the comparison analysis page.
+
+        :trigger: ``input.comparison`` — fires when the user clicks the COMPARISON
+            nav button.
+
+        """
         active_module.set("comparison")
 
     # The page is always divided into a sidebar region and workspace region

--- a/tfbpshiny/components.py
+++ b/tfbpshiny/components.py
@@ -54,7 +54,7 @@ CSS variable reference (from ``app.css`` ``:root``)
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any
+from typing import Any, Literal
 
 from shiny import ui
 
@@ -100,6 +100,13 @@ def sidebar_shell(
 
     CSS: ``.context-sidebar``, ``.sidebar-header``, ``.sidebar-body``,
     ``.sidebar-footer``
+
+    .. note::
+        The Select Datasets sidebar uses ``context-sidebar selection-sidebar``
+        and ``sidebar-header-row`` CSS modifiers that are not factored into
+        component functions here. Those classes appear only once, in
+        ``select_datasets/server/sidebar.py``, and carry collapsed-state
+        conditional logic that makes a generic factory impractical.
     """
     children: list[Any] = [
         ui.div({"class": "sidebar-header"}, header),
@@ -148,24 +155,21 @@ def sidebar_subtitle(text: str) -> ui.Tag:
     return ui.div({"class": "subtitle"}, text)
 
 
-def sidebar_section_title(text: str) -> ui.Tag:
+def sidebar_section(title: str, *children: Any) -> ui.Tag:
     """
-    Label for a named group of controls within a sidebar section.
+    Wrapper div that groups related sidebar controls under a labelled heading.
 
-    CSS: ``.sidebar-section-title``
+    CSS: ``.sidebar-section``, ``.sidebar-section-title``
 
-    """
-    return ui.div({"class": "sidebar-section-title"}, text)
-
-
-def sidebar_section(*children: Any) -> ui.Tag:
-    """
-    Wrapper div that groups related sidebar controls with consistent spacing.
-
-    CSS: ``.sidebar-section``
+    :param title: Short label rendered above the controls (e.g. ``"Column"``).
+    :param children: One or more Shiny input elements placed below the title.
 
     """
-    return ui.div({"class": "sidebar-section"}, *children)
+    return ui.div(
+        {"class": "sidebar-section"},
+        ui.div({"class": "sidebar-section-title"}, title),
+        *children,
+    )
 
 
 def group_header(text: str) -> ui.Tag:
@@ -371,20 +375,117 @@ def modal_section(*cards: ui.Tag) -> ui.Tag:
 # ---------------------------------------------------------------------------
 
 
-def matrix_cell_button(id: str, label: str) -> ui.Tag:
+def matrix_cell_button(id: str, label: str, *, tooltip: str | None = None) -> ui.Tag:
     """
-    Full-width, borderless button that fills a matrix table cell.
+    Full-width, borderless Shiny action button that fills a matrix table cell.
 
     CSS: ``.matrix-cell-button``
 
-    These are plain ``<button>`` tags rather than Shiny action buttons because
-    they live inside a ``@render.ui`` that rebuilds the entire matrix; each
-    click is routed through a single observer via a JavaScript onclick.
+    :param id: Shiny input ID for the button (e.g. ``"diag_harbison"``).
+    :param label: Text displayed inside the button.
+    :param tooltip: When provided, sets the native ``title`` attribute so browsers
+        show a hover tooltip.
 
     """
-    return ui.tags.button(
-        {"class": "matrix-cell-button", "id": id},
-        label,
+    attrs: dict[str, str] = {"class": "matrix-cell-button"}
+    if tooltip is not None:
+        attrs["title"] = tooltip
+    return ui.input_action_button(id, label, **attrs)
+
+
+def matrix_header_cell(label: str, *, row: bool = False) -> ui.Tag:
+    """
+    Header cell (``<th>``) for the intersection matrix.
+
+    CSS:
+
+    - ``row=False`` (default) — column header: ``.matrix-col-header``,
+      ``.matrix-header-name``. Used for each dataset column in the top row.
+    - ``row=True`` — row header: ``.matrix-row-header``. Used for the first
+      ``<th>`` in the header row (typically labelled ``"Dataset"``).
+
+    :param label: Text shown in the header cell.
+    :param row: When ``True``, renders as a row header rather than a column header.
+
+    """
+    if row:
+        return ui.tags.th({"class": "matrix-row-header"}, label)
+    return ui.tags.th(
+        {"class": "matrix-col-header"},
+        ui.div({"class": "matrix-header-name"}, label),
+    )
+
+
+def matrix_row_label(label: str) -> ui.Tag:
+    """
+    Row label cell (``<td>``) showing the dataset name at the start of each row.
+
+    CSS: ``.matrix-row-label``
+
+    :param label: Dataset display name.
+
+    """
+    return ui.tags.td({"class": "matrix-row-label"}, label)
+
+
+def matrix_cell(
+    kind: Literal["empty", "diagonal", "interactive"],
+    button: ui.Tag | None = None,
+    *,
+    active: bool = False,
+) -> ui.Tag:
+    """
+    Data cell (``<td>``) in the intersection matrix.
+
+    CSS by ``kind``:
+
+    - ``"empty"`` — lower-triangle placeholder: ``.matrix-cell-empty``.
+      No button; ``button`` argument is ignored.
+    - ``"diagonal"`` — on-diagonal cell showing regulator/sample counts for one
+      dataset: ``.matrix-cell-diagonal``. Wraps a ``matrix_cell_button``.
+    - ``"interactive"`` — upper-triangle cell showing the common-regulator count
+      for a dataset pair: ``.matrix-cell-interactive``. Wraps a
+      ``matrix_cell_button``. When ``active=True`` also adds
+      ``.matrix-cell-active`` to highlight the pair whose intersection is the
+      current regulator filter.
+
+    :param kind: One of ``"empty"``, ``"diagonal"``, or ``"interactive"``.
+    :param button: A ``matrix_cell_button`` element. Required for ``"diagonal"``
+        and ``"interactive"``; ignored for ``"empty"``.
+    :param active: Only relevant for ``kind="interactive"``. Adds
+        ``.matrix-cell-active`` when ``True``.
+
+    """
+    if kind == "empty":
+        return ui.tags.td({"class": "matrix-cell-empty"}, "")
+    if kind == "diagonal":
+        return ui.tags.td({"class": "matrix-cell-diagonal"}, button)
+    # interactive
+    cls = (
+        "matrix-cell-interactive matrix-cell-active"
+        if active
+        else "matrix-cell-interactive"
+    )
+    return ui.tags.td({"class": cls}, button)
+
+
+def matrix_table(header_row: ui.Tag, *body_rows: ui.Tag) -> ui.Tag:
+    """
+    Full intersection matrix ``<table>``.
+
+    CSS: ``.matrix-summary-table``
+
+    :param header_row: A ``<tr>`` built from ``matrix_row_header`` and
+        ``matrix_col_header`` cells.
+    :param body_rows: One ``<tr>`` per active dataset, built from
+        ``matrix_row_label``, ``matrix_cell_empty``, ``matrix_cell_diagonal``,
+        and ``matrix_cell_interactive`` cells.
+
+    """
+    return ui.tags.table(
+        {"class": "matrix-summary-table"},
+        ui.tags.thead(header_row),
+        ui.tags.tbody(*body_rows),
     )
 
 
@@ -395,6 +496,7 @@ __all__ = [
     # sidebar typography
     "sidebar_heading",
     "sidebar_subtitle",
+    "sidebar_section",
     "group_header",
     "sidebar_text",
     # workspace typography
@@ -414,4 +516,8 @@ __all__ = [
     "modal_section",
     # matrix
     "matrix_cell_button",
+    "matrix_header_cell",
+    "matrix_row_label",
+    "matrix_cell",
+    "matrix_table",
 ]

--- a/tfbpshiny/modules/binding/server/sidebar.py
+++ b/tfbpshiny/modules/binding/server/sidebar.py
@@ -9,7 +9,7 @@ from typing import Any
 from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
-from tfbpshiny.components import sidebar_section, sidebar_section_title
+from tfbpshiny.components import sidebar_section
 
 
 @module.server
@@ -76,7 +76,7 @@ def binding_sidebar_server(
 
         return ui.div(
             sidebar_section(
-                sidebar_section_title("Column"),
+                "Column",
                 ui.input_radio_buttons(
                     "col_preference",
                     label=None,
@@ -86,7 +86,7 @@ def binding_sidebar_server(
                 ),
             ),
             sidebar_section(
-                sidebar_section_title("Correlation"),
+                "Correlation",
                 ui.input_radio_buttons(
                     "corr_type",
                     label=None,

--- a/tfbpshiny/modules/binding/server/workspace.py
+++ b/tfbpshiny/modules/binding/server/workspace.py
@@ -273,8 +273,6 @@ def binding_workspace_server(
             return ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False))
 
     def _build_regulator_plots() -> ui.Tag:
-        from plotly.subplots import make_subplots
-
         try:
             reg = str(input.selected_regulator()) or None
         except Exception:
@@ -285,9 +283,8 @@ def binding_workspace_server(
         filters = dataset_filters()
         method = corr_type()
 
-        fig = go.Figure()
-
         if not reg or not pairs:
+            fig = go.Figure()
             fig.add_annotation(
                 text="Select a regulator above to see per-pair scatter plots.",
                 xref="paper",
@@ -298,12 +295,9 @@ def binding_workspace_server(
             )
             return ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False))
 
-        n = len(pairs)
-        subplot_titles = [
-            f"{display_names.get(db_a, db_a)} vs {display_names.get(db_b, db_b)}"
-            for db_a, db_b in pairs
-        ]
-        fig = make_subplots(rows=1, cols=n, subplot_titles=subplot_titles)
+        # First pass: collect data and track which datasets are missing the regulator
+        pair_data: list[tuple[str, str, str, str, object]] = []
+        missing_datasets: set[str] = set()
 
         for idx, (db_a, db_b) in enumerate(pairs, start=1):
             try:
@@ -326,12 +320,20 @@ def binding_workspace_server(
                 continue
 
             if merged.empty:
+                missing_datasets.add(display_names.get(db_a, db_a))
+                missing_datasets.add(display_names.get(db_b, db_b))
                 continue
 
-            r = merged["_val_a"].corr(merged["_val_b"])
+            pair_data.append((db_a, db_b, col_a, col_b, merged))
+
+        # Build one figure per valid pair
+        plot_divs: list[ui.Tag] = []
+        for db_a, db_b, col_a, col_b, merged in pair_data:
             la = display_names.get(db_a, db_a)
             lb = display_names.get(db_b, db_b)
+            r = merged["_val_a"].corr(merged["_val_b"])
 
+            fig = go.Figure()
             fig.add_trace(
                 go.Scatter(
                     x=merged["_val_a"],
@@ -344,21 +346,57 @@ def binding_workspace_server(
                         + f"{la}: %{{x:.3f}}<br>"
                         + f"{lb}: %{{y:.3f}}<extra></extra>"
                     ),
-                    name=f"r={r:.3f}",
                     showlegend=False,
-                ),
-                row=1,
-                col=idx,
+                )
             )
-            fig.update_xaxes(title_text=f"{la}: {col_a}", row=1, col=idx)
-            fig.update_yaxes(title_text=f"{lb}: {col_b}", row=1, col=idx)
-            fig.layout.annotations[idx - 1].text += f"  (r={r:.3f})"
+            fig.add_annotation(
+                text=f"r={r:.3f}",
+                xref="paper",
+                yref="paper",
+                x=0.98,
+                y=0.98,
+                xanchor="right",
+                yanchor="top",
+                showarrow=False,
+                font=dict(size=12),
+            )
+            fig.update_layout(
+                title=dict(
+                    text=f"{la}<br>vs<br>{lb}",
+                    x=0.5,
+                    xanchor="center",
+                ),
+                xaxis_title=f"{la}: {col_a}",
+                yaxis_title=f"{lb}: {col_b}",
+                margin=dict(l=50, r=20, t=100, b=50),
+                width=400,
+                height=400,
+            )
+            plot_divs.append(
+                ui.div(
+                    ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False)),
+                    style="flex: 0 0 auto;",
+                )
+            )
 
-        fig.update_layout(
-            title=f"Regulator: {reg}",
-            margin=dict(l=40, r=20, t=70, b=50),
+        missing_note: list[ui.Tag] = []
+        if missing_datasets:
+            names = ", ".join(sorted(missing_datasets))
+            missing_note.append(
+                ui.p(
+                    f"{reg} was not found in: {names}. "
+                    "Pairs involving these datasets are omitted.",
+                    style="color: gray; font-style: italic; margin: 0.5rem 0;",
+                )
+            )
+
+        return ui.div(
+            *missing_note,
+            ui.div(
+                *plot_divs,
+                style="display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start;",  # noqa: E501
+            ),
         )
-        return ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False))
 
 
 __all__ = ["binding_workspace_server"]

--- a/tfbpshiny/modules/binding/server/workspace.py
+++ b/tfbpshiny/modules/binding/server/workspace.py
@@ -225,18 +225,21 @@ def binding_workspace_server(
             if not df.empty:
                 all_regs |= set(df["regulator_locus_tag"].dropna().unique())
 
-        regs = sorted(all_regs)
-        if not regs:
+        if not all_regs:
             return ui.span()
-        choices = {r: sym_map.get(r, r) or r for r in regs}
+        choices = {
+            r: f"{sym} ({r})" if (sym := sym_map.get(r) or "") else r
+            for r in sorted(all_regs)
+        }
+        choices = dict(sorted(choices.items(), key=lambda kv: kv[1].lower()))
 
         try:
             current = str(input.selected_regulator())
         except Exception:
             current = ""
-        default = current if current in choices else regs[0]
+        default = current if current in choices else next(iter(choices))
 
-        return ui.input_select(
+        return ui.input_selectize(
             "selected_regulator",
             "Regulator",
             choices=choices,
@@ -386,7 +389,7 @@ def binding_workspace_server(
                 ui.p(
                     f"{reg} was not found in: {names}. "
                     "Pairs involving these datasets are omitted.",
-                    style="color: gray; font-style: italic; margin: 0.5rem 0;",
+                    style="color: gray; margin: 0.5rem 0;",
                 )
             )
 

--- a/tfbpshiny/modules/comparison/server/sidebar.py
+++ b/tfbpshiny/modules/comparison/server/sidebar.py
@@ -9,7 +9,7 @@ from typing import Any
 from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
-from tfbpshiny.components import sidebar_section, sidebar_section_title
+from tfbpshiny.components import sidebar_section
 from tfbpshiny.modules.comparison.queries import (
     DEFAULT_EFFECT_THRESHOLD,
     DEFAULT_PVALUE_THRESHOLD,
@@ -119,7 +119,7 @@ def comparison_sidebar_server(
         return ui.div(
             # DTO section — no controls
             sidebar_section(
-                sidebar_section_title("Dual Threshold Optimization"),
+                "Dual Threshold Optimization",
                 ui.p(
                     {"class": "text-muted", "style": "font-size:0.85em;"},
                     "DTO results are pre-computed; no parameters to set.",
@@ -128,7 +128,7 @@ def comparison_sidebar_server(
             ui.hr(),
             # Top-N section
             sidebar_section(
-                sidebar_section_title("Top N by Binding"),
+                "Top N by Binding",
                 ui.input_numeric(
                     "top_n",
                     "Top N",
@@ -137,7 +137,7 @@ def comparison_sidebar_server(
                     max=500,
                     step=5,
                 ),
-                sidebar_section_title("Responsive threshold"),
+                ui.div({"class": "sidebar-section-title"}, "Responsive threshold"),
                 ui.input_slider(
                     "effect_threshold",
                     "Min |effect|",
@@ -154,7 +154,7 @@ def comparison_sidebar_server(
                     value=pvalue_threshold(),
                     step=0.001,
                 ),
-                sidebar_section_title("Facet by"),
+                ui.div({"class": "sidebar-section-title"}, "Facet by"),
                 ui.input_radio_buttons(
                     "facet_by",
                     label=None,

--- a/tfbpshiny/modules/perturbation/server/sidebar.py
+++ b/tfbpshiny/modules/perturbation/server/sidebar.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from shiny import module, reactive, render, ui
 
-from tfbpshiny.components import sidebar_section, sidebar_section_title
+from tfbpshiny.components import sidebar_section
 
 
 @module.server
@@ -75,7 +75,7 @@ def perturbation_sidebar_server(
 
         return ui.div(
             sidebar_section(
-                sidebar_section_title("Column"),
+                "Column",
                 ui.input_radio_buttons(
                     "col_preference",
                     label=None,
@@ -85,7 +85,7 @@ def perturbation_sidebar_server(
                 ),
             ),
             sidebar_section(
-                sidebar_section_title("Correlation"),
+                "Correlation",
                 ui.input_radio_buttons(
                     "corr_type",
                     label=None,

--- a/tfbpshiny/modules/perturbation/server/workspace.py
+++ b/tfbpshiny/modules/perturbation/server/workspace.py
@@ -223,18 +223,21 @@ def perturbation_workspace_server(
             if not df.empty:
                 all_regs |= set(df["regulator_locus_tag"].dropna().unique())
 
-        regs = sorted(all_regs)
-        if not regs:
+        if not all_regs:
             return ui.span()
-        choices = {r: sym_map.get(r, r) or r for r in regs}
+        choices = {
+            r: f"{sym} ({r})" if (sym := sym_map.get(r) or "") else r
+            for r in sorted(all_regs)
+        }
+        choices = dict(sorted(choices.items(), key=lambda kv: kv[1].lower()))
 
         try:
             current = str(input.selected_regulator())
         except Exception:
             current = ""
-        default = current if current in choices else regs[0]
+        default = current if current in choices else next(iter(choices))
 
-        return ui.input_select(
+        return ui.input_selectize(
             "selected_regulator",
             "Regulator",
             choices=choices,

--- a/tfbpshiny/modules/perturbation/server/workspace.py
+++ b/tfbpshiny/modules/perturbation/server/workspace.py
@@ -271,8 +271,6 @@ def perturbation_workspace_server(
             return ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False))
 
     def _build_regulator_plots() -> ui.Tag:
-        from plotly.subplots import make_subplots
-
         try:
             reg = str(input.selected_regulator()) or None
         except Exception:
@@ -283,9 +281,8 @@ def perturbation_workspace_server(
         filters = dataset_filters()
         method = corr_type()
 
-        fig = go.Figure()
-
         if not reg or not pairs:
+            fig = go.Figure()
             fig.add_annotation(
                 text="Select a regulator above to see per-pair scatter plots.",
                 xref="paper",
@@ -296,12 +293,9 @@ def perturbation_workspace_server(
             )
             return ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False))
 
-        n = len(pairs)
-        subplot_titles = [
-            f"{display_names.get(db_a, db_a)} vs {display_names.get(db_b, db_b)}"
-            for db_a, db_b in pairs
-        ]
-        fig = make_subplots(rows=1, cols=n, subplot_titles=subplot_titles)
+        # First pass: collect data and track which datasets are missing the regulator
+        pair_data: list[tuple[str, str, str, str, object]] = []
+        missing_datasets: set[str] = set()
 
         for idx, (db_a, db_b) in enumerate(pairs, start=1):
             try:
@@ -324,12 +318,20 @@ def perturbation_workspace_server(
                 continue
 
             if merged.empty:
+                missing_datasets.add(display_names.get(db_a, db_a))
+                missing_datasets.add(display_names.get(db_b, db_b))
                 continue
 
-            r = merged["_val_a"].corr(merged["_val_b"])
+            pair_data.append((db_a, db_b, col_a, col_b, merged))
+
+        # Build one figure per valid pair
+        plot_divs: list[ui.Tag] = []
+        for db_a, db_b, col_a, col_b, merged in pair_data:
             la = display_names.get(db_a, db_a)
             lb = display_names.get(db_b, db_b)
+            r = merged["_val_a"].corr(merged["_val_b"])
 
+            fig = go.Figure()
             fig.add_trace(
                 go.Scatter(
                     x=merged["_val_a"],
@@ -342,21 +344,57 @@ def perturbation_workspace_server(
                         + f"{la}: %{{x:.3f}}<br>"
                         + f"{lb}: %{{y:.3f}}<extra></extra>"
                     ),
-                    name=f"r={r:.3f}",
                     showlegend=False,
-                ),
-                row=1,
-                col=idx,
+                )
             )
-            fig.update_xaxes(title_text=f"{la}: {col_a}", row=1, col=idx)
-            fig.update_yaxes(title_text=f"{lb}: {col_b}", row=1, col=idx)
-            fig.layout.annotations[idx - 1].text += f"  (r={r:.3f})"
+            fig.add_annotation(
+                text=f"r={r:.3f}",
+                xref="paper",
+                yref="paper",
+                x=0.98,
+                y=0.98,
+                xanchor="right",
+                yanchor="top",
+                showarrow=False,
+                font=dict(size=12),
+            )
+            fig.update_layout(
+                title=dict(
+                    text=f"{la}<br>vs<br>{lb}",
+                    x=0.5,
+                    xanchor="center",
+                ),
+                xaxis_title=f"{la}: {col_a}",
+                yaxis_title=f"{lb}: {col_b}",
+                margin=dict(l=50, r=20, t=100, b=50),
+                width=400,
+                height=400,
+            )
+            plot_divs.append(
+                ui.div(
+                    ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False)),
+                    style="flex: 0 0 auto;",
+                )
+            )
 
-        fig.update_layout(
-            title=f"Regulator: {reg}",
-            margin=dict(l=40, r=20, t=70, b=50),
+        missing_note: list[ui.Tag] = []
+        if missing_datasets:
+            names = ", ".join(sorted(missing_datasets))
+            missing_note.append(
+                ui.p(
+                    f"{reg} was not found in: {names}. "
+                    "Pairs involving these datasets are omitted.",
+                    style="color: gray; font-style: italic; margin: 0.5rem 0;",
+                )
+            )
+
+        return ui.div(
+            *missing_note,
+            ui.div(
+                *plot_divs,
+                style="display: flex; flex-wrap: wrap; gap: 1rem; align-items: flex-start;",  # noqa: E501
+            ),
         )
-        return ui.HTML(to_html(fig, include_plotlyjs=False, full_html=False))
 
 
 __all__ = ["perturbation_workspace_server"]

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -130,9 +130,65 @@ def regulator_locus_tags_query(
     )
 
 
+def regulator_breakdown_query(
+    db_name: str,
+    candidate_cols: list[str],
+    filters: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Return ``(sql, params)`` for a single query that counts multi-sample regulators and
+    distinct values per candidate column in one pass.
+
+    The result is a single row with:
+
+    - ``n_multi`` — number of regulators that appear in more than one sample
+    - One column per entry in ``candidate_cols`` — the number of distinct
+      values for that column across multi-sample regulators only
+
+    If ``n_multi`` is 0 every regulator maps to exactly one sample (uniform).
+    Otherwise, candidate columns where the count is > 1 are the differentiating
+    columns.
+
+    :param db_name: Dataset name.
+    :param candidate_cols: Columns to check, pre-filtered to exclude identity
+        and hidden fields.
+    :param filters: Active filters for this dataset.
+    :return: ``(sql_string, params_dict)``.
+
+    """
+    params: dict[str, Any] = {}
+    where = _build_where(filters, params)
+    # per_reg: for each multi-sample regulator, count distinct values per column
+    per_reg_exprs = ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in candidate_cols)
+    # agg: count how many regulators show internal variation (per-regulator distinct > 1)
+    agg_exprs = ", ".join(
+        f'COUNT(*) FILTER (WHERE "{c}" > 1) AS "{c}"' for c in candidate_cols
+    )
+    sql = (
+        f"WITH multi AS ("
+        f"  SELECT regulator_locus_tag"
+        f"  FROM {db_name}_meta{where}"
+        f"  GROUP BY regulator_locus_tag"
+        f"  HAVING COUNT(*) > 1"
+        f"), per_reg AS ("
+        f"  SELECT regulator_locus_tag"
+        + (f", {per_reg_exprs}" if per_reg_exprs else "")
+        + f"  FROM {db_name}_meta{where}"
+        + (" AND" if where else " WHERE")
+        + f" regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+        f"  GROUP BY regulator_locus_tag"
+        f") "
+        f"SELECT COUNT(*) AS n_multi"
+        + (f", {agg_exprs}" if agg_exprs else "")
+        + f" FROM per_reg"
+    )
+    return sql, params
+
+
 __all__ = [
     "FIELD_TYPE_OVERRIDES",
     "metadata_query",
     "sample_count_query",
     "regulator_locus_tags_query",
+    "regulator_breakdown_query",
 ]

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -185,10 +185,31 @@ def regulator_breakdown_query(
     return sql, params
 
 
+def regulator_display_labels_query(db_name: str) -> tuple[str, dict]:
+    """
+    Return ``(sql, params)`` for fetching distinct regulator locus tags and symbols.
+
+    Used to build the ``{locus_tag: "SYMBOL (LOCUS_TAG)"}`` display map for the
+    Regulator selectize in the filter modal.
+
+    :param db_name: Dataset name.
+    :return: ``(sql_string, params_dict)`` — rows have columns
+        ``regulator_locus_tag`` and ``regulator_symbol``.
+
+    """
+    return (
+        f"SELECT DISTINCT regulator_locus_tag, regulator_symbol"
+        f" FROM {db_name}_meta"
+        f" ORDER BY regulator_locus_tag",
+        {},
+    )
+
+
 __all__ = [
     "FIELD_TYPE_OVERRIDES",
     "metadata_query",
     "sample_count_query",
     "regulator_locus_tags_query",
     "regulator_breakdown_query",
+    "regulator_display_labels_query",
 ]

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -130,9 +130,54 @@ def regulator_locus_tags_query(
     )
 
 
+def regulator_breakdown_query(
+    db_name: str,
+    candidate_cols: list[str],
+    filters: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Return ``(sql, params)`` for a single query that counts multi-sample regulators and
+    distinct values per candidate column in one pass.
+
+    The result is a single row with:
+
+    - ``n_multi`` — number of regulators that appear in more than one sample
+    - One column per entry in ``candidate_cols`` — the number of distinct
+      values for that column across multi-sample regulators only
+
+    If ``n_multi`` is 0 every regulator maps to exactly one sample (uniform).
+    Otherwise, candidate columns where the count is > 1 are the differentiating
+    columns.
+
+    :param db_name: Dataset name.
+    :param candidate_cols: Columns to check, pre-filtered to exclude identity
+        and hidden fields.
+    :param filters: Active filters for this dataset.
+    :return: ``(sql_string, params_dict)``.
+
+    """
+    params: dict[str, Any] = {}
+    where = _build_where(filters, params)
+    count_exprs = ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in candidate_cols)
+    sql = (
+        f"WITH multi AS ("
+        f"  SELECT regulator_locus_tag"
+        f"  FROM {db_name}_meta{where}"
+        f"  GROUP BY regulator_locus_tag"
+        f"  HAVING COUNT(*) > 1"
+        f") "
+        f"SELECT COUNT(*) AS n_multi"
+        + (f", {count_exprs}" if count_exprs else "")
+        + f" FROM {db_name}_meta{where}"
+        f" WHERE regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+    )
+    return sql, params
+
+
 __all__ = [
     "FIELD_TYPE_OVERRIDES",
     "metadata_query",
     "sample_count_query",
     "regulator_locus_tags_query",
+    "regulator_breakdown_query",
 ]

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -158,18 +158,29 @@ def regulator_breakdown_query(
     """
     params: dict[str, Any] = {}
     where = _build_where(filters, params)
-    count_exprs = ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in candidate_cols)
+    # per_reg: for each multi-sample regulator, count distinct values per column
+    per_reg_exprs = ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in candidate_cols)
+    # agg: count how many regulators show internal variation (per-regulator distinct > 1)
+    agg_exprs = ", ".join(
+        f'COUNT(*) FILTER (WHERE "{c}" > 1) AS "{c}"' for c in candidate_cols
+    )
     sql = (
         f"WITH multi AS ("
         f"  SELECT regulator_locus_tag"
         f"  FROM {db_name}_meta{where}"
         f"  GROUP BY regulator_locus_tag"
         f"  HAVING COUNT(*) > 1"
+        f"), per_reg AS ("
+        f"  SELECT regulator_locus_tag"
+        + (f", {per_reg_exprs}" if per_reg_exprs else "")
+        + f"  FROM {db_name}_meta{where}"
+        + (" AND" if where else " WHERE")
+        + f" regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+        f"  GROUP BY regulator_locus_tag"
         f") "
         f"SELECT COUNT(*) AS n_multi"
-        + (f", {count_exprs}" if count_exprs else "")
-        + f" FROM {db_name}_meta{where}"
-        f" WHERE regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+        + (f", {agg_exprs}" if agg_exprs else "")
+        + f" FROM per_reg"
     )
     return sql, params
 

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -175,12 +175,12 @@ def regulator_breakdown_query(
         + (f", {per_reg_exprs}" if per_reg_exprs else "")
         + f"  FROM {db_name}_meta{where}"
         + (" AND" if where else " WHERE")
-        + f" regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
-        f"  GROUP BY regulator_locus_tag"
-        f") "
-        f"SELECT COUNT(*) AS n_multi"
+        + " regulator_locus_tag IN (SELECT regulator_locus_tag FROM multi)"
+        "  GROUP BY regulator_locus_tag"
+        ") "
+        "SELECT COUNT(*) AS n_multi"
         + (f", {agg_exprs}" if agg_exprs else "")
-        + f" FROM per_reg"
+        + " FROM per_reg"
     )
     return sql, params
 

--- a/tfbpshiny/modules/select_datasets/server/sidebar.py
+++ b/tfbpshiny/modules/select_datasets/server/sidebar.py
@@ -14,6 +14,7 @@ from shiny import module, reactive, render, ui
 from tfbpshiny.modules.select_datasets.queries import (
     FIELD_TYPE_OVERRIDES,
     metadata_query,
+    regulator_display_labels_query,
 )
 from tfbpshiny.modules.select_datasets.ui import _slugify, dataset_filter_modal_ui
 
@@ -22,7 +23,12 @@ from tfbpshiny.modules.select_datasets.ui import _slugify, dataset_filter_modal_
 # datasets; use the db_name key for dataset-specific exclusions. The effective
 # hidden set for a given dataset is the union of "*" and its own entry.
 HIDDEN_FILTER_FIELDS: dict[str, set[str]] = {
-    "*": {"regulator_locus_tag", "regulator_symbol"},
+    "*": {
+        "regulator_locus_tag",
+        "regulator_symbol",
+        "Regulator locus tag",
+        "Regulator symbol",
+    },
     "callingcards": {"background_total_hops", "experiment_total_hops"},
     "harbison": {"condition"},
     "chec_m2025": {"condition", "mahendrawada_symbol"},
@@ -210,6 +216,21 @@ def select_datasets_sidebar_server(
                             pass
                     common_field_levels[cf_field] = list(levels)
 
+                # build {locus_tag: "SYMBOL (LOCUS_TAG)"} map for regulator selectize
+                reg_display_labels: dict[str, str] = {}
+                try:
+                    reg_sql, reg_params = regulator_display_labels_query(db_name)
+                    reg_df = vdb.query(reg_sql, **reg_params)
+                    for _, row in reg_df.iterrows():
+                        tag = str(row["regulator_locus_tag"])
+                        sym = row.get("regulator_symbol")
+                        label = f"{sym} ({tag})" if sym and str(sym) != "nan" else tag
+                        reg_display_labels[tag] = label
+                except Exception:
+                    logger.exception(
+                        f"Failed to fetch regulator display labels for {db_name}"
+                    )
+
                 ui.modal_show(
                     dataset_filter_modal_ui(
                         db_name,
@@ -220,6 +241,7 @@ def select_datasets_sidebar_server(
                         common_field_levels=common_field_levels,
                         hidden_fields=HIDDEN_FILTER_FIELDS.get("*", set())
                         | HIDDEN_FILTER_FIELDS.get(db_name, set()),
+                        regulator_display_labels=reg_display_labels or None,
                     )
                 )
 
@@ -257,6 +279,33 @@ def select_datasets_sidebar_server(
         ui.modal_remove()
         modal_open_for.set(None)
         modal_df.set(None)
+
+    @reactive.effect
+    @reactive.event(input.modal_clear_regulator_filter)
+    def _clear_regulator_filter() -> None:
+        """
+        Remove ``regulator_locus_tag`` from all datasets and clear the selectize in the
+        open modal in place via ``ui.update_selectize``.
+
+        :trigger input.modal_clear_regulator_filter: fires when the user clicks the
+        Clear button inside the Regulator card of a filter modal.
+
+        """
+        db_name = modal_open_for()
+        if db_name is None:
+            return
+        all_db_names = [d for d, _ in binding_datasets + perturbation_datasets]
+        current = dict(dataset_filters())
+        for ds in all_db_names:
+            ds_filters = dict(current.get(ds, {}))
+            ds_filters.pop("regulator_locus_tag", None)
+            if ds_filters:
+                current[ds] = ds_filters
+            else:
+                current.pop(ds, None)
+        dataset_filters.set(current)
+        # clear the selectize in place — no modal teardown/re-show needed
+        ui.update_selectize("filter_regulator_locus_tag", selected=[])
 
     @reactive.effect
     @reactive.event(input.modal_apply_filters)
@@ -332,7 +381,32 @@ def select_datasets_sidebar_server(
                     apply_to_all = False
                 field_filters[field]["apply_to_all"] = apply_to_all
 
+        # handle regulator_locus_tag explicitly (hidden from generic field loop)
+        try:
+            reg_selected = list(input["filter_regulator_locus_tag"]())
+        except Exception:
+            reg_selected = []
+        try:
+            reg_apply_to_all = bool(input["apply_to_all_regulator_locus_tag"]())
+        except Exception:
+            reg_apply_to_all = True
+        if reg_selected:
+            saved_reg = (
+                dataset_filters().get(db_name, {}).get("regulator_locus_tag", {})
+            )
+            from_pair = saved_reg.get("from_pair") if saved_reg else None
+            reg_spec: dict[str, Any] = {
+                "type": "categorical",
+                "value": reg_selected,
+                "apply_to_all": reg_apply_to_all,
+            }
+            if from_pair:
+                reg_spec["from_pair"] = from_pair
+            field_filters["regulator_locus_tag"] = reg_spec
+
         # split into common-field filters and dataset-specific
+        # regulator_locus_tag is treated as a common field for propagation purposes
+        reg_filter = field_filters.pop("regulator_locus_tag", None)
         common_filters = {f: v for f, v in field_filters.items() if f in common_fields}
         specific_filters = {
             f: v for f, v in field_filters.items() if f not in common_fields
@@ -340,6 +414,34 @@ def select_datasets_sidebar_server(
 
         current = dict(dataset_filters())
         all_db_names = [d for d, _ in binding_datasets + perturbation_datasets]
+
+        # apply regulator filter (or clear it if empty)
+        if reg_filter:
+            if reg_filter.get("apply_to_all", True):
+                for ds in all_db_names:
+                    ds_filters = dict(current.get(ds, {}))
+                    ds_filters["regulator_locus_tag"] = reg_filter
+                    current[ds] = ds_filters
+            else:
+                for ds in all_db_names:
+                    ds_filters = dict(current.get(ds, {}))
+                    if ds == db_name:
+                        ds_filters["regulator_locus_tag"] = reg_filter
+                    else:
+                        ds_filters.pop("regulator_locus_tag", None)
+                    if ds_filters:
+                        current[ds] = ds_filters
+                    else:
+                        current.pop(ds, None)
+        else:
+            # regulator field was cleared — remove from all datasets
+            for ds in all_db_names:
+                ds_filters = dict(current.get(ds, {}))
+                ds_filters.pop("regulator_locus_tag", None)
+                if ds_filters:
+                    current[ds] = ds_filters
+                else:
+                    current.pop(ds, None)
 
         # apply each common filter according to its own apply_to_all flag
         for f, spec in common_filters.items():

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -102,7 +102,7 @@ def select_datasets_workspace_server(
         """
         Create the modal and contents on click of a diagonal cell.
 
-        The modal text will describe whether there is a 1-1 correspondance between
+        The modal text will describe whether there is a 1-1 correspondence between
         regulators and samples. If there are not, then it will list the metadata columns
         that differentiate samples with the same regulator.
 

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -9,9 +9,11 @@ from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
 from tfbpshiny.modules.select_datasets.queries import (
+    regulator_breakdown_query,
     regulator_locus_tags_query,
     sample_count_query,
 )
+from tfbpshiny.modules.select_datasets.server.sidebar import HIDDEN_FILTER_FIELDS
 from tfbpshiny.modules.select_datasets.ui import (
     diagonal_cell_modal_ui,
     off_diagonal_cell_modal_ui,
@@ -97,13 +99,51 @@ def select_datasets_workspace_server(
         return {"diagonal": diagonal, "cross_dataset": cross_dataset}
 
     def _make_diagonal_effect(db_name: str) -> None:
-        """Register a per-dataset click effect for a diagonal cell button."""
+        """
+        Create the modal and contents on click of a diagonal cell.
+
+        The modal text will describe whether there is a 1-1 correspondence between
+        regulators and samples. If there are not, then it will list the metadata columns
+        that differentiate samples with the same regulator.
+
+        """
         btn_id = f"diag_{db_name}"
 
         @reactive.effect
         @reactive.event(input[btn_id])
         def _on_click() -> None:
-            ui.modal_show(diagonal_cell_modal_ui())
+            filters = dataset_filters().get(db_name)
+
+            all_cols = vdb.get_fields(f"{db_name}_meta")
+            # TODO: this is a good use case for the field `role` experimental
+            # condition -- only use experimental condition fields and remove
+            # any hidden filter fields
+            remove_cols = (
+                {"sample_id"}
+                | {c for c in all_cols if c.lower().startswith("regulator")}
+                | HIDDEN_FILTER_FIELDS.get("*", set())
+                | HIDDEN_FILTER_FIELDS.get(db_name, set())
+            )
+            candidate_cols = [c for c in all_cols if c not in remove_cols]
+
+            sql, params = regulator_breakdown_query(db_name, candidate_cols, filters)
+            row = vdb.query(sql, **params).iloc[0]
+            n_multi = int(row["n_multi"])
+
+            if n_multi == 0:
+                multi_regulator_sample_breakdown: dict = {"uniform": True}
+            else:
+                diff_cols = [c for c in candidate_cols if row[c] > 0]
+                multi_regulator_sample_breakdown = {
+                    "uniform": False,
+                    "n_multi": n_multi,
+                    "differentiating_columns": diff_cols,
+                }
+
+            display_name = display_names.get(db_name, db_name)
+            ui.modal_show(
+                diagonal_cell_modal_ui(display_name, multi_regulator_sample_breakdown)
+            )
 
     def _make_off_diagonal_effect(db_a: str, db_b: str) -> None:
         """Register per-pair click and modal-action effects for an off-diagonal cell."""

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -9,9 +9,11 @@ from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
 from tfbpshiny.modules.select_datasets.queries import (
+    regulator_breakdown_query,
     regulator_locus_tags_query,
     sample_count_query,
 )
+from tfbpshiny.modules.select_datasets.server.sidebar import HIDDEN_FILTER_FIELDS
 from tfbpshiny.modules.select_datasets.ui import (
     diagonal_cell_modal_ui,
     off_diagonal_cell_modal_ui,
@@ -97,13 +99,51 @@ def select_datasets_workspace_server(
         return {"diagonal": diagonal, "cross_dataset": cross_dataset}
 
     def _make_diagonal_effect(db_name: str) -> None:
-        """Register a per-dataset click effect for a diagonal cell button."""
+        """
+        Create the modal and contents on click of a diagonal cell.
+
+        The modal text will describe whether there is a 1-1 correspondance between
+        regulators and samples. If there are not, then it will list the metadata columns
+        that differentiate samples with the same regulator.
+
+        """
         btn_id = f"diag_{db_name}"
 
         @reactive.effect
         @reactive.event(input[btn_id])
         def _on_click() -> None:
-            ui.modal_show(diagonal_cell_modal_ui())
+            filters = dataset_filters().get(db_name)
+
+            all_cols = vdb.get_fields(f"{db_name}_meta")
+            # TODO: this is a good use case for the field `role` experimental
+            # condition -- only use experimental condition fields and remove
+            # any hidden filter fields
+            remove_cols = (
+                {"sample_id"}
+                | {c for c in all_cols if c.lower().startswith("regulator")}
+                | HIDDEN_FILTER_FIELDS.get("*", set())
+                | HIDDEN_FILTER_FIELDS.get(db_name, set())
+            )
+            candidate_cols = [c for c in all_cols if c not in remove_cols]
+
+            sql, params = regulator_breakdown_query(db_name, candidate_cols, filters)
+            row = vdb.query(sql, **params).iloc[0]
+            n_multi = int(row["n_multi"])
+
+            if n_multi == 0:
+                multi_regulator_sample_breakdown: dict = {"uniform": True}
+            else:
+                diff_cols = [c for c in candidate_cols if row[c] > 1]
+                multi_regulator_sample_breakdown = {
+                    "uniform": False,
+                    "n_multi": n_multi,
+                    "differentiating_columns": diff_cols,
+                }
+
+            display_name = display_names.get(db_name, db_name)
+            ui.modal_show(
+                diagonal_cell_modal_ui(display_name, multi_regulator_sample_breakdown)
+            )
 
     def _make_off_diagonal_effect(db_a: str, db_b: str) -> None:
         """Register per-pair click and modal-action effects for an off-diagonal cell."""

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -8,6 +8,13 @@ from typing import Any
 from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
+from tfbpshiny.components import (
+    matrix_cell,
+    matrix_cell_button,
+    matrix_header_cell,
+    matrix_row_label,
+    matrix_table,
+)
 from tfbpshiny.modules.select_datasets.queries import (
     regulator_breakdown_query,
     regulator_locus_tags_query,
@@ -40,6 +47,14 @@ def select_datasets_workspace_server(
 
     @reactive.calc
     def _active_datasets() -> list[str]:
+        """
+        Combined list of all currently active binding and perturbation datasets.
+
+        :trigger: ``active_binding_datasets``, ``active_perturbation_datasets`` —
+            re-runs whenever either list changes.
+        :returns: Concatenated list of active db_name strings, binding first.
+
+        """
         return active_binding_datasets() + active_perturbation_datasets()
 
     @reactive.calc
@@ -48,9 +63,12 @@ def select_datasets_workspace_server(
         Compute per-dataset regulator/sample counts and pairwise common-regulator counts
         with restricted sample counts.
 
-        :return: Dict with keys: ``"diagonal"`` — ``{db_name: {"regulators": int,
-            "samples": int}}`` ``"cross_dataset"`` — ``{(db_i, db_j):
-            {"common_regulators": int, "samples_a": int, "samples_b": int}}``
+        :trigger: ``_active_datasets`` — re-runs when the active dataset list changes.
+            ``dataset_filters`` — re-runs when any filter changes, since filters
+            affect regulator and sample counts.
+        :returns: Dict with keys: ``"diagonal"`` — ``{db_name: {"regulators": int,
+            "samples": int}}``; ``"cross_dataset"`` — ``{(db_i, db_j):
+            {"common_regulators": int, "samples_a": int, "samples_b": int}}``.
 
         """
         active = _active_datasets()
@@ -112,6 +130,14 @@ def select_datasets_workspace_server(
         @reactive.effect
         @reactive.event(input[btn_id])
         def _on_click() -> None:
+            """
+            Compute regulator/sample multiplicity for this dataset and show the diagonal
+            cell modal.
+
+            :trigger: ``input[diag_{db_name}]`` — fires when the user clicks the
+                diagonal matrix cell button for this dataset.
+
+            """
             filters = dataset_filters().get(db_name)
 
             all_cols = vdb.get_fields(f"{db_name}_meta")
@@ -153,9 +179,31 @@ def select_datasets_workspace_server(
         @reactive.effect
         @reactive.event(input[btn_id])
         def _on_click() -> None:
+            """
+            If this pair is the active regulator filter, clear the filter and
+            unhighlight the cell. Otherwise, show the off-diagonal cell modal.
+
+            :trigger: ``input[offdiag_{db_a}__{db_b}]`` — fires when the user
+                clicks the off-diagonal matrix cell button for this pair.
+
+            """
+            if _active_regulator_pair() == (db_a, db_b):
+                # Remove regulator_locus_tag from all datasets and clear highlight.
+                current = dict(dataset_filters())
+                for db_name in list(current):
+                    ds_filters = dict(current[db_name])
+                    ds_filters.pop("regulator_locus_tag", None)
+                    if ds_filters:
+                        current[db_name] = ds_filters
+                    else:
+                        current.pop(db_name)
+                dataset_filters.set(current)
+                _active_regulator_pair.set(None)
+                return
             data = _matrix_data()
             info = data["cross_dataset"].get((db_a, db_b), {})
             n_common = info.get("common_regulators", 0)
+            _open_modal_pair.set((db_a, db_b))
             ui.modal_show(
                 off_diagonal_cell_modal_ui(
                     display_names.get(db_a, db_a),
@@ -167,6 +215,20 @@ def select_datasets_workspace_server(
         @reactive.effect
         @reactive.event(input[apply_btn_id])
         def _on_apply_common_regulators() -> None:
+            """
+            Compute the regulator intersection for this pair, write it as a
+            ``regulator_locus_tag`` filter to all datasets, and highlight the cell.
+
+            Only acts when this pair's modal is the one currently open, preventing
+            all registered apply effects from firing on a single button click.
+
+            :trigger: ``input[modal_select_common_regulators]`` — fires when the
+                user clicks the "Select common regulators" button in the off-diagonal
+                modal.
+
+            """
+            if _open_modal_pair() != (db_a, db_b):
+                return
             reg_sets = {}
             filters = dataset_filters()
             for db_name in (db_a, db_b):
@@ -188,16 +250,34 @@ def select_datasets_workspace_server(
                 ui.modal_remove()
                 return
             current = dict(dataset_filters())
-            for db_name in _active_datasets():
+            pair_display = (
+                display_names.get(db_a, db_a),
+                display_names.get(db_b, db_b),
+            )
+            for db_name in vdb.get_datasets():
                 ds_filters = dict(current.get(db_name, {}))
                 ds_filters.pop("regulator_locus_tag", None)
                 ds_filters["regulator_locus_tag"] = {
                     "type": "categorical",
                     "value": common,
+                    "from_pair": pair_display,
                 }
                 current[db_name] = ds_filters
             dataset_filters.set(current)
+            _active_regulator_pair.set((db_a, db_b))
+            _open_modal_pair.set(None)
             ui.modal_remove()
+
+    # Tracks the (db_a, db_b) pair whose intersection is the current regulator filter.
+    # Used to highlight that cell in the matrix. None when no pairwise filter is active.
+    _active_regulator_pair: reactive.Value[tuple[str, str] | None] = reactive.value(
+        None
+    )
+
+    # Tracks which pair's off-diagonal modal is currently open.
+    # All _on_apply_common_regulators effects share the same button ID, so this
+    # guards against every registered effect firing on a single Apply click.
+    _open_modal_pair: reactive.Value[tuple[str, str] | None] = reactive.value(None)
 
     # Track which cell effects have already been registered to avoid duplicates
     # when active_datasets changes but some datasets remain.
@@ -205,6 +285,15 @@ def select_datasets_workspace_server(
 
     @reactive.effect
     def _register_cell_effects() -> None:
+        """
+        Register click effects for any newly active dataset cells that have not yet been
+        registered, avoiding duplicate effect registration.
+
+        :trigger: ``_active_datasets`` — re-runs whenever the active dataset list
+            changes so that new diagonal and off-diagonal cell effects are created
+            for any newly added datasets.
+
+        """
         active = _active_datasets()
         for db_name in active:
             if db_name not in _registered_effects:
@@ -216,6 +305,23 @@ def select_datasets_workspace_server(
                 if pair_id not in _registered_effects:
                     _make_off_diagonal_effect(db_a, db_b)
                     _registered_effects.add(pair_id)
+
+    @reactive.effect
+    def _clear_pair_when_filter_removed() -> None:
+        """
+        Clear the highlighted cell pair when no ``regulator_locus_tag`` filter remains
+        in ``dataset_filters``.
+
+        :trigger: ``dataset_filters`` — re-runs on every filter change; clears
+            ``_active_regulator_pair`` once the regulator filter has been removed.
+
+        """
+        filters = dataset_filters()
+        has_reg_filter = any(
+            "regulator_locus_tag" in (v or {}) for v in filters.values()
+        )
+        if not has_reg_filter:
+            _active_regulator_pair.set(None)
 
     @render.ui
     def matrix_content() -> ui.Tag:
@@ -247,42 +353,31 @@ def select_datasets_workspace_server(
         cross_dataset = data["cross_dataset"]
 
         # --- header row ---
-        header_cells = [ui.tags.th({"class": "matrix-row-header"}, "Dataset")]
+        header_cells = [matrix_header_cell("Dataset", row=True)]
         for db_name in active:
-            label = display_names.get(db_name, db_name)
-            header_cells.append(
-                ui.tags.th(
-                    {"class": "matrix-col-header"},
-                    ui.div({"class": "matrix-header-name"}, label),
-                )
-            )
+            header_cells.append(matrix_header_cell(display_names.get(db_name, db_name)))
 
         # --- body rows ---
         body_rows: list[ui.Tag] = []
         for row_i, db_row in enumerate(active):
-            cells: list[ui.Tag] = [
-                ui.tags.td(
-                    {"class": "matrix-row-label"}, display_names.get(db_row, db_row)
-                )
-            ]
+            cells: list[ui.Tag] = [matrix_row_label(display_names.get(db_row, db_row))]
 
             for col_i, db_col in enumerate(active):
                 if col_i < row_i:
                     # lower triangle — empty
-                    cells.append(ui.tags.td({"class": "matrix-cell-empty"}, ""))
+                    cells.append(matrix_cell("empty"))
                     continue
 
                 if col_i == row_i:
                     # diagonal — regulator count + sample count
                     info = diagonal.get(db_row, {})
                     cells.append(
-                        ui.tags.td(
-                            {"class": "matrix-cell-diagonal"},
-                            ui.input_action_button(
+                        matrix_cell(
+                            "diagonal",
+                            matrix_cell_button(
                                 f"diag_{db_row}",
                                 f"{info.get('regulators', 0):,} regulators / "
                                 f"{info.get('samples', 0):,} samples",
-                                class_="matrix-cell-button",
                             ),
                         )
                     )
@@ -290,25 +385,27 @@ def select_datasets_workspace_server(
                     # upper triangle — common regulators only
                     key = (db_row, db_col)
                     info = cross_dataset.get(key, {})
+                    is_active = _active_regulator_pair() == (db_row, db_col)
                     cells.append(
-                        ui.tags.td(
-                            {"class": "matrix-cell-interactive"},
-                            ui.input_action_button(
+                        matrix_cell(
+                            "interactive",
+                            matrix_cell_button(
                                 f"offdiag_{db_row}__{db_col}",
                                 f"{info.get('common_regulators', 0):,} "
                                 "common regulators",
-                                class_="matrix-cell-button",
+                                tooltip=(
+                                    "Click to remove the regulator filter"
+                                    if is_active
+                                    else None
+                                ),
                             ),
+                            active=is_active,
                         )
                     )
 
             body_rows.append(ui.tags.tr(*cells))
 
-        return ui.tags.table(
-            {"class": "matrix-summary-table"},
-            ui.tags.thead(ui.tags.tr(*header_cells)),
-            ui.tags.tbody(*body_rows),
-        )
+        return matrix_table(ui.tags.tr(*header_cells), *body_rows)
 
 
 __all__ = ["select_datasets_workspace_server"]

--- a/tfbpshiny/modules/select_datasets/server/workspace.py
+++ b/tfbpshiny/modules/select_datasets/server/workspace.py
@@ -133,7 +133,7 @@ def select_datasets_workspace_server(
             if n_multi == 0:
                 multi_regulator_sample_breakdown: dict = {"uniform": True}
             else:
-                diff_cols = [c for c in candidate_cols if row[c] > 1]
+                diff_cols = [c for c in candidate_cols if row[c] > 0]
                 multi_regulator_sample_breakdown = {
                     "uniform": False,
                     "n_multi": n_multi,

--- a/tfbpshiny/modules/select_datasets/ui.py
+++ b/tfbpshiny/modules/select_datasets/ui.py
@@ -146,6 +146,7 @@ def dataset_filter_modal_ui(
     display_name: str | None = None,
     common_field_levels: dict[str, list[str]] | None = None,
     hidden_fields: set[str] | None = None,
+    regulator_display_labels: dict[str, str] | None = None,
 ) -> ui.Tag:
     """
     Build the filter modal for a given dataset from live metadata.
@@ -166,6 +167,9 @@ def dataset_filter_modal_ui(
     :param common_field_levels: For common categorical fields, the union of factor
         levels across all active datasets. Used to populate the selectize choices
         so that valid values from other datasets remain selectable.
+    :param regulator_display_labels: Maps ``locus_tag`` to ``"SYMBOL (LOCUS_TAG)"``
+        display strings. When provided, a Regulator card is prepended to the Common
+        Characteristics column with a combined searchable selectize.
 
     """
     saved = saved_filters or {}
@@ -198,8 +202,87 @@ def dataset_filter_modal_ui(
         else:
             specific_cards.append(card)
 
+    # --- regulator card (prepended to common column) ---
+    regulator_card: list[ui.Tag] = []
+    if regulator_display_labels is not None:
+        saved_reg = saved.get("regulator_locus_tag", {})
+        selected_reg = saved_reg.get("value", []) if saved_reg else []
+        from_pair: tuple[str, str] | None = (
+            saved_reg.get("from_pair") if saved_reg else None
+        )
+        apply_to_all_reg = saved_reg.get("apply_to_all", True) if saved_reg else True
+
+        if from_pair:
+            # Pairwise regulator filter is active: restrict choices to the intersection
+            # of this dataset's regulators with the active filter values; show a note.
+            # The selectize starts empty — the pairwise filter is implicit context,
+            # not a pre-selection. The user may optionally narrow further by picking
+            # from the available restricted choices.
+            restricted_choices = {
+                tag: label
+                for tag, label in regulator_display_labels.items()
+                if tag in selected_reg
+            }
+            regulator_card = [
+                ui.div(
+                    {"class": "filter-option-card"},
+                    ui.div(
+                        {"class": "filter-option-header"},
+                        ui.span({"class": "filter-option-title"}, "Regulator"),
+                    ),
+                    ui.p(
+                        {
+                            "class": "text-muted",
+                            "style": "font-size:0.8rem; margin-bottom:6px;",
+                        },
+                        f"Regulators are limited to the {len(selected_reg):,} common "
+                        f"regulators between {from_pair[0]} and {from_pair[1]}. "
+                        "To clear this, deselect the highlighted cell in the matrix.",
+                    ),
+                    ui.input_selectize(
+                        "filter_regulator_locus_tag",
+                        label=None,
+                        choices=restricted_choices,
+                        selected=[],
+                        multiple=True,
+                        options={"plugins": ["remove_button"]},
+                    ),
+                )
+            ]
+        else:
+            regulator_card = [
+                ui.div(
+                    {"class": "filter-option-card"},
+                    ui.div(
+                        {"class": "filter-option-header"},
+                        ui.span({"class": "filter-option-title"}, "Regulator"),
+                        ui.div(
+                            {"style": "display:flex; align-items:center; gap:0.5rem;"},
+                            ui.input_action_button(
+                                "modal_clear_regulator_filter",
+                                "Clear",
+                                class_="btn btn-sm btn-outline-secondary",
+                            ),
+                            ui.input_switch(
+                                "apply_to_all_regulator_locus_tag",
+                                "Apply to all datasets",
+                                value=apply_to_all_reg,
+                            ),
+                        ),
+                    ),
+                    ui.input_selectize(
+                        "filter_regulator_locus_tag",
+                        label=None,
+                        choices=regulator_display_labels,
+                        selected=selected_reg,
+                        multiple=True,
+                        options={"plugins": ["remove_button"]},
+                    ),
+                )
+            ]
+
     # --- common characteristics column ---
-    if common_cards:
+    if common_cards or regulator_card:
         common_col_children: list[ui.Tag] = [
             _section_heading("Common Characteristics"),
             ui.p(
@@ -209,6 +292,7 @@ def dataset_filter_modal_ui(
                 },
                 "These characteristics appear in every dataset.",
             ),
+            *regulator_card,
             *common_cards,
         ]
     else:

--- a/tfbpshiny/modules/select_datasets/ui.py
+++ b/tfbpshiny/modules/select_datasets/ui.py
@@ -283,10 +283,39 @@ def selection_matrix_ui() -> ui.Tag:
     )
 
 
-def diagonal_cell_modal_ui() -> ui.Tag:
-    """Placeholder modal for diagonal (single-dataset) matrix cells."""
+def diagonal_cell_modal_ui(display_name: str, breakdown: dict) -> ui.Tag:
+    """
+    Modal for diagonal matrix cells summarising sample/regulator multiplicity.
+
+    This will either say that each sample interrogates a unique regulator,
+    or provide information about which columns differentiate samples that share
+    regulators.
+
+    :param display_name: Human-readable dataset name for the modal title.
+    :param breakdown: Dict produced by the multiplicity analysis in workspace.py.
+        ``{"uniform": True}`` when each regulator maps to exactly one sample;
+        ``{"uniform": False, "n_multi": int, "differentiating_columns": list[str]}``
+        otherwise.
+
+    """
+    if breakdown.get("uniform"):
+        body = ui.p("Each sample represents a unique interrogated regulator.")
+    else:
+        cols = breakdown.get("differentiating_columns", [])
+        body = ui.div(
+            ui.p(
+                f"{breakdown['n_multi']:,} regulators appear in multiple samples. "
+                f"Samples differ by:"
+            ),
+            (
+                ui.tags.ul(*[ui.tags.li(c) for c in cols])
+                if cols
+                else ui.p(ui.tags.em("unknown columns"))
+            ),
+        )
     return ui.modal(
-        ui.p("diagonal"),
+        body,
+        title=display_name,
         easy_close=True,
         footer=ui.modal_button("Close"),
     )


### PR DESCRIPTION
This depends on #206 and #218 getting merged first. Do not do the review until both #206 and #218 have been merged to dev. Then rebase this onto dev and review.

- Closes #190 -- the non-diag button sets a filter on regulators, so the regulator display in the filter needed to be addressed. went ahead applied the same thing to the binding and perturbation modules)

- Closes #187 -- same reason as above

- Closes #188 -- this was already true, no changes

- Closes #201 -- a non-diag modal now offers the option to set a filter on the intersect regulators between two datasets. Clicking the action button sets the filter and highlights the cell in the matrix (necessitating some refactoring of the components that make up the matrix to add options like hightlight, etc). A note is then added to that effect in the filter modals, but the regulator field is non pre-populated b/c that broke the regulator filtering functionality (the available regulators are just reduced to those that intersect with the active pairwise filter). To clear the pairwise filter, the user clicks on the highlighted cell.
