### PR TITLE
feat: add export button to download selected datasets as tarball

### DIFF
--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import tarfile
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import duckdb
 import pandas as pd
 import pytest
 
 from tfbpshiny.modules.select_datasets.export import (
     ExportDataset,
+    _query_to_csv_bytes,
     _safe_dir_name,
     build_export_tarball,
     build_readme,
@@ -110,68 +111,115 @@ def test_get_dataset_description_empty_description():
     assert get_dataset_description(vdb, "harbison") is None
 
 
+# --- DuckDB-backed test fixtures ---
+
+
+@pytest.fixture
+def duckdb_vdb():
+    """
+    Minimal VirtualDB stub backed by a real in-memory DuckDB connection.
+
+    Mirrors export.py's use of vdb._conn — update both if VirtualDB changes.
+
+    """
+    conn = duckdb.connect(":memory:")
+    conn.execute(
+        """
+        CREATE TABLE test_meta AS
+        SELECT 's1' AS sample_id, 'BY4741' AS strain
+        UNION ALL
+        SELECT 's2', 'BY4741'
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE test_data AS
+        SELECT 's1' AS sample_id, 'YAL001C' AS gene, 1.0 AS value
+        UNION ALL
+        SELECT 's1', 'YAL002W', 2.0
+        """
+    )
+    vdb = MagicMock()
+    vdb._conn = conn
+    yield vdb
+    conn.close()
+
+
+def _open_tarball(buf):
+    """Open a BytesIO buffer as a tarball for reading."""
+    buf.seek(0)
+    return tarfile.open(fileobj=buf, mode="r:gz")
+
+
+# --- _query_to_csv_bytes ---
+
+
+def test_query_to_csv_bytes(duckdb_vdb):
+    cursor = duckdb_vdb._conn.cursor()
+    csv_bytes = _query_to_csv_bytes(cursor, "SELECT * FROM test_meta", {})
+    text = csv_bytes.decode("utf-8")
+    assert "sample_id" in text
+    assert "BY4741" in text
+    lines = text.strip().split("\n")
+    assert len(lines) == 3  # header + 2 rows
+
+
+def test_query_to_csv_bytes_uses_lf_line_endings(duckdb_vdb):
+    """csv.writer must produce LF (not CRLF) for Unix tool compatibility."""
+    cursor = duckdb_vdb._conn.cursor()
+    csv_bytes = _query_to_csv_bytes(cursor, "SELECT * FROM test_meta", {})
+    assert b"\r\n" not in csv_bytes
+    assert b"\n" in csv_bytes
+
+
 # --- build_export_tarball ---
 
 
-def _sample_metadata() -> pd.DataFrame:
-    return pd.DataFrame({"sample_id": ["s1", "s2"], "strain": ["BY4741", "BY4741"]})
-
-
-def _sample_data() -> pd.DataFrame:
-    return pd.DataFrame(
-        {"sample_id": ["s1", "s1"], "gene": ["YAL001C", "YAL002W"], "value": [1.0, 2.0]}
+def _make_export_dataset(
+    display_name: str = "Test Dataset",
+    description: str | None = None,
+) -> ExportDataset:
+    return ExportDataset(
+        display_name=display_name,
+        metadata_sql="SELECT * FROM test_meta",
+        metadata_params={},
+        data_sql="SELECT * FROM test_data",
+        data_params={},
+        description=description,
     )
 
 
-def test_single_dataset_with_description(tmp_path: Path):
-    ds = ExportDataset(
+def test_single_dataset_with_description(duckdb_vdb):
+    ds = _make_export_dataset(
         display_name="2026 Calling Cards",
-        metadata_df=_sample_metadata(),
-        data_df=_sample_data(),
         description="A binding dataset.",
     )
-    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
-    assert out.exists()
+    buf = build_export_tarball([ds], duckdb_vdb)
 
-    with tarfile.open(out, "r:gz") as tar:
+    with _open_tarball(buf) as tar:
         names = tar.getnames()
         assert "2026_Calling_Cards/metadata.csv" in names
         assert "2026_Calling_Cards/annotated_features.csv" in names
         assert "2026_Calling_Cards/README.md" in names
 
 
-def test_single_dataset_without_description(tmp_path: Path):
-    ds = ExportDataset(
-        display_name="Test Dataset",
-        metadata_df=_sample_metadata(),
-        data_df=_sample_data(),
-        description=None,
-    )
-    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+def test_single_dataset_without_description(duckdb_vdb):
+    ds = _make_export_dataset(display_name="Test Dataset")
+    buf = build_export_tarball([ds], duckdb_vdb)
 
-    with tarfile.open(out, "r:gz") as tar:
+    with _open_tarball(buf) as tar:
         names = tar.getnames()
         assert "Test_Dataset/metadata.csv" in names
         assert "Test_Dataset/annotated_features.csv" in names
         assert "Test_Dataset/README.md" not in names
 
 
-def test_multiple_datasets(tmp_path: Path):
-    ds1 = ExportDataset(
-        display_name="Dataset A",
-        metadata_df=_sample_metadata(),
-        data_df=_sample_data(),
-        description="First.",
-    )
-    ds2 = ExportDataset(
-        display_name="Dataset B",
-        metadata_df=_sample_metadata(),
-        data_df=_sample_data(),
-        description=None,
-    )
-    out = build_export_tarball([ds1, ds2], tmp_path / "export.tar.gz")
+def test_multiple_datasets(duckdb_vdb):
+    ds1 = _make_export_dataset(display_name="Dataset A", description="First.")
+    ds2 = _make_export_dataset(display_name="Dataset B")
+    buf = build_export_tarball([ds1, ds2], duckdb_vdb)
 
-    with tarfile.open(out, "r:gz") as tar:
+    with _open_tarball(buf) as tar:
         names = tar.getnames()
         assert "Dataset_A/metadata.csv" in names
         assert "Dataset_B/metadata.csv" in names
@@ -179,64 +227,47 @@ def test_multiple_datasets(tmp_path: Path):
         assert "Dataset_B/README.md" not in names
 
 
-def test_csv_content_matches_input(tmp_path: Path):
-    meta = _sample_metadata()
-    data = _sample_data()
-    ds = ExportDataset(
-        display_name="Check",
-        metadata_df=meta,
-        data_df=data,
-        description=None,
-    )
-    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+def test_csv_content_matches_query(duckdb_vdb):
+    ds = _make_export_dataset(display_name="Check")
+    buf = build_export_tarball([ds], duckdb_vdb)
 
-    with tarfile.open(out, "r:gz") as tar:
+    with _open_tarball(buf) as tar:
         meta_member = tar.extractfile("Check/metadata.csv")
         assert meta_member is not None
         recovered_meta = pd.read_csv(meta_member)
-        pd.testing.assert_frame_equal(recovered_meta, meta)
+        assert list(recovered_meta.columns) == ["sample_id", "strain"]
+        assert len(recovered_meta) == 2
 
         data_member = tar.extractfile("Check/annotated_features.csv")
         assert data_member is not None
         recovered_data = pd.read_csv(data_member)
-        pd.testing.assert_frame_equal(recovered_data, data)
+        assert "gene" in recovered_data.columns
+        assert len(recovered_data) == 2
 
 
-def test_empty_dataframes(tmp_path: Path):
-    ds = ExportDataset(
-        display_name="Empty",
-        metadata_df=pd.DataFrame(columns=["sample_id"]),
-        data_df=pd.DataFrame(columns=["sample_id", "gene"]),
-        description=None,
-    )
-    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
-
-    with tarfile.open(out, "r:gz") as tar:
-        meta_member = tar.extractfile("Empty/metadata.csv")
-        assert meta_member is not None
-        recovered = pd.read_csv(meta_member)
-        assert list(recovered.columns) == ["sample_id"]
-        assert len(recovered) == 0
-
-
-def test_empty_dataset_list(tmp_path: Path):
-    out = build_export_tarball([], tmp_path / "empty.tar.gz")
-    assert out.exists()
-    with tarfile.open(out, "r:gz") as tar:
+def test_empty_dataset_list(duckdb_vdb):
+    buf = build_export_tarball([], duckdb_vdb)
+    with _open_tarball(buf) as tar:
         assert tar.getnames() == []
 
 
-def test_tarball_no_path_traversal(tmp_path: Path):
+def test_tarball_no_path_traversal(duckdb_vdb):
     """Verify that adversarial display_names never produce traversal paths."""
-    ds = ExportDataset(
+    ds = _make_export_dataset(
         display_name="../../../etc/cron.d/backdoor",
-        metadata_df=_sample_metadata(),
-        data_df=_sample_data(),
-        description=None,
     )
-    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+    buf = build_export_tarball([ds], duckdb_vdb)
 
-    with tarfile.open(out, "r:gz") as tar:
+    with _open_tarball(buf) as tar:
         for member in tar.getmembers():
             assert not member.name.startswith("/")
             assert ".." not in member.name.split("/")
+
+
+def test_progress_callback_called(duckdb_vdb):
+    """Verify the progress callback fires once per dataset."""
+    ds1 = _make_export_dataset(display_name="A")
+    ds2 = _make_export_dataset(display_name="B")
+    names: list[str] = []
+    build_export_tarball([ds1, ds2], duckdb_vdb, progress_callback=names.append)
+    assert names == ["A", "B"]

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,0 +1,242 @@
+"""Unit tests for the dataset export helpers."""
+
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from tfbpshiny.modules.select_datasets.export import (
+    ExportDataset,
+    _safe_dir_name,
+    build_export_tarball,
+    build_readme,
+    get_dataset_description,
+)
+
+# --- _safe_dir_name ---
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2026 Calling Cards", "2026_Calling_Cards"),
+        ("simple", "simple"),
+        ("has-hyphen", "has-hyphen"),
+        ("has.dot", "has.dot"),
+        ("../evil", "evil"),
+        ("../../etc/passwd", "etc_passwd"),
+        ("/absolute/path", "absolute_path"),
+        ("name\x00null", "name_null"),
+        ("a/b", "a_b"),
+        ("   spaces   ", "spaces"),
+        ("...", "dataset"),
+        ("___", "dataset"),
+        ("", "dataset"),
+    ],
+)
+def test_safe_dir_name(raw: str, expected: str) -> None:
+    assert _safe_dir_name(raw) == expected
+
+
+# --- build_readme ---
+
+
+def test_build_readme_includes_display_name():
+    result = build_readme("2026 Calling Cards", "A binding dataset.")
+    assert "# 2026 Calling Cards" in result
+
+
+def test_build_readme_includes_description():
+    result = build_readme("Test", "Some description text.")
+    assert "Some description text." in result
+
+
+def test_build_readme_includes_file_explanations():
+    result = build_readme("Test", "desc")
+    assert "metadata.csv" in result
+    assert "annotated_features.csv" in result
+    assert "Sample-level metadata" in result
+    assert "Full genomic data" in result
+
+
+# --- get_dataset_description ---
+
+
+def _make_mock_vdb(
+    db_name: str = "harbison",
+    repo_id: str = "BrentLab/repo",
+    config_name: str = "harbison",
+    description: str | None = "A description",
+) -> MagicMock:
+    # Mocks private VirtualDB attrs; update when public API lands (issue #213).
+    vdb = MagicMock()
+    vdb._db_name_map = {db_name: (repo_id, config_name)}
+    config = SimpleNamespace(description=description)
+    card = MagicMock()
+    card.get_config.return_value = config
+    vdb._datacards = {repo_id: card}
+    return vdb
+
+
+def test_get_dataset_description_happy_path():
+    vdb = _make_mock_vdb(description="Harbison ChIP-chip data.")
+    assert get_dataset_description(vdb, "harbison") == "Harbison ChIP-chip data."
+
+
+def test_get_dataset_description_no_card():
+    vdb = _make_mock_vdb()
+    vdb._datacards = {}
+    assert get_dataset_description(vdb, "harbison") is None
+
+
+def test_get_dataset_description_no_config():
+    vdb = _make_mock_vdb()
+    vdb._datacards["BrentLab/repo"].get_config.return_value = None
+    assert get_dataset_description(vdb, "harbison") is None
+
+
+def test_get_dataset_description_unknown_db_name():
+    vdb = _make_mock_vdb()
+    assert get_dataset_description(vdb, "nonexistent") is None
+
+
+def test_get_dataset_description_empty_description():
+    vdb = _make_mock_vdb(description="")
+    assert get_dataset_description(vdb, "harbison") is None
+
+
+# --- build_export_tarball ---
+
+
+def _sample_metadata() -> pd.DataFrame:
+    return pd.DataFrame({"sample_id": ["s1", "s2"], "strain": ["BY4741", "BY4741"]})
+
+
+def _sample_data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"sample_id": ["s1", "s1"], "gene": ["YAL001C", "YAL002W"], "value": [1.0, 2.0]}
+    )
+
+
+def test_single_dataset_with_description(tmp_path: Path):
+    ds = ExportDataset(
+        display_name="2026 Calling Cards",
+        metadata_df=_sample_metadata(),
+        data_df=_sample_data(),
+        description="A binding dataset.",
+    )
+    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+    assert out.exists()
+
+    with tarfile.open(out, "r:gz") as tar:
+        names = tar.getnames()
+        assert "2026_Calling_Cards/metadata.csv" in names
+        assert "2026_Calling_Cards/annotated_features.csv" in names
+        assert "2026_Calling_Cards/README.md" in names
+
+
+def test_single_dataset_without_description(tmp_path: Path):
+    ds = ExportDataset(
+        display_name="Test Dataset",
+        metadata_df=_sample_metadata(),
+        data_df=_sample_data(),
+        description=None,
+    )
+    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+
+    with tarfile.open(out, "r:gz") as tar:
+        names = tar.getnames()
+        assert "Test_Dataset/metadata.csv" in names
+        assert "Test_Dataset/annotated_features.csv" in names
+        assert "Test_Dataset/README.md" not in names
+
+
+def test_multiple_datasets(tmp_path: Path):
+    ds1 = ExportDataset(
+        display_name="Dataset A",
+        metadata_df=_sample_metadata(),
+        data_df=_sample_data(),
+        description="First.",
+    )
+    ds2 = ExportDataset(
+        display_name="Dataset B",
+        metadata_df=_sample_metadata(),
+        data_df=_sample_data(),
+        description=None,
+    )
+    out = build_export_tarball([ds1, ds2], tmp_path / "export.tar.gz")
+
+    with tarfile.open(out, "r:gz") as tar:
+        names = tar.getnames()
+        assert "Dataset_A/metadata.csv" in names
+        assert "Dataset_B/metadata.csv" in names
+        assert "Dataset_A/README.md" in names
+        assert "Dataset_B/README.md" not in names
+
+
+def test_csv_content_matches_input(tmp_path: Path):
+    meta = _sample_metadata()
+    data = _sample_data()
+    ds = ExportDataset(
+        display_name="Check",
+        metadata_df=meta,
+        data_df=data,
+        description=None,
+    )
+    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+
+    with tarfile.open(out, "r:gz") as tar:
+        meta_member = tar.extractfile("Check/metadata.csv")
+        assert meta_member is not None
+        recovered_meta = pd.read_csv(meta_member)
+        pd.testing.assert_frame_equal(recovered_meta, meta)
+
+        data_member = tar.extractfile("Check/annotated_features.csv")
+        assert data_member is not None
+        recovered_data = pd.read_csv(data_member)
+        pd.testing.assert_frame_equal(recovered_data, data)
+
+
+def test_empty_dataframes(tmp_path: Path):
+    ds = ExportDataset(
+        display_name="Empty",
+        metadata_df=pd.DataFrame(columns=["sample_id"]),
+        data_df=pd.DataFrame(columns=["sample_id", "gene"]),
+        description=None,
+    )
+    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+
+    with tarfile.open(out, "r:gz") as tar:
+        meta_member = tar.extractfile("Empty/metadata.csv")
+        assert meta_member is not None
+        recovered = pd.read_csv(meta_member)
+        assert list(recovered.columns) == ["sample_id"]
+        assert len(recovered) == 0
+
+
+def test_empty_dataset_list(tmp_path: Path):
+    out = build_export_tarball([], tmp_path / "empty.tar.gz")
+    assert out.exists()
+    with tarfile.open(out, "r:gz") as tar:
+        assert tar.getnames() == []
+
+
+def test_tarball_no_path_traversal(tmp_path: Path):
+    """Verify that adversarial display_names never produce traversal paths."""
+    ds = ExportDataset(
+        display_name="../../../etc/cron.d/backdoor",
+        metadata_df=_sample_metadata(),
+        data_df=_sample_data(),
+        description=None,
+    )
+    out = build_export_tarball([ds], tmp_path / "export.tar.gz")
+
+    with tarfile.open(out, "r:gz") as tar:
+        for member in tar.getmembers():
+            assert not member.name.startswith("/")
+            assert ".." not in member.name.split("/")

--- a/tests/unit/test_select_datasets.py
+++ b/tests/unit/test_select_datasets.py
@@ -2,6 +2,7 @@
 
 from tfbpshiny.modules.select_datasets.queries import (
     _build_where,
+    full_data_query,
     metadata_query,
     regulator_breakdown_query,
     regulator_display_labels_query,
@@ -132,6 +133,22 @@ def test_regulator_breakdown_query_with_filters():
     # filters produce WHERE; the regulator IN clause must use AND, not a second WHERE
     assert "AND regulator_locus_tag IN" in sql
     assert sql.count("WHERE") == 3  # filters appear in both multi and per_reg CTEs
+
+
+def test_full_data_query_no_filters():
+    sql, params = full_data_query("harbison")
+    assert sql == "SELECT * FROM harbison"
+    assert params == {}
+
+
+def test_full_data_query_with_filter():
+    sql, params = full_data_query(
+        "harbison", {"strain": {"type": "categorical", "value": ["BY4741"]}}
+    )
+    assert "WHERE" in sql
+    assert "harbison" in sql
+    assert "harbison_meta" not in sql
+    assert "BY4741" in params.values()
 
 
 def test_regulator_breakdown_query_no_filters_uses_where():

--- a/tfbpshiny/app.css
+++ b/tfbpshiny/app.css
@@ -146,6 +146,7 @@ body {
     padding: 12px 16px;
     border-top: 1px solid var(--color-border);
     background: var(--color-surface);
+    text-align: left;
 }
 
 /* --- Main workspace ----------------------------------------------------- */
@@ -419,7 +420,7 @@ body {
     display: none;
 }
 
-.btn-export-datasets {
+.sidebar-footer .btn-export-datasets {
     width: 100%;
     background: var(--color-primary);
     color: #fff;
@@ -429,14 +430,13 @@ body {
     font-size: var(--font-size-base);
     font-weight: 600;
     cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+    display: block;
+    text-align: left;
     gap: 6px;
     transition: background var(--transition-fast);
 }
 
-.btn-export-datasets:hover {
+.sidebar-footer .btn-export-datasets:hover {
     background: var(--color-primary-dark);
     color: #fff;
 }

--- a/tfbpshiny/app.css
+++ b/tfbpshiny/app.css
@@ -414,6 +414,33 @@ body {
     color: #FFFFFF;
 }
 
+/* --- Export button (sidebar footer) ------------------------------------- */
+.selection-sidebar.collapsed .sidebar-footer {
+    display: none;
+}
+
+.btn-export-datasets {
+    width: 100%;
+    background: var(--color-primary);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius-sm);
+    padding: 8px 12px;
+    font-size: var(--font-size-base);
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    transition: background var(--transition-fast);
+}
+
+.btn-export-datasets:hover {
+    background: var(--color-primary-dark);
+    color: #fff;
+}
+
 /* --- Dataset filter modal ----------------------------------------------- */
 .modal-section {
     display: flex;

--- a/tfbpshiny/components.py
+++ b/tfbpshiny/components.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any, Literal
 
+import faicons as fa
 from shiny import ui
 
 # ---------------------------------------------------------------------------
@@ -489,6 +490,23 @@ def matrix_table(header_row: ui.Tag, *body_rows: ui.Tag) -> ui.Tag:
     )
 
 
+def export_download_button(id: str) -> ui.Tag:
+    """
+    Full-width download button for exporting selected datasets as a tarball.
+
+    CSS: ``.btn-export-datasets``
+
+    :param id: Shiny download ID (paired with a ``@render.download`` handler).
+
+    """
+    return ui.download_button(
+        id,
+        "Export Selected Datasets",
+        icon=fa.icon_svg("download", width="14px", height="14px"),
+        class_="btn-export-datasets",
+    )
+
+
 __all__ = [
     # layout
     "sidebar_shell",
@@ -520,4 +538,6 @@ __all__ = [
     "matrix_row_label",
     "matrix_cell",
     "matrix_table",
+    # export
+    "export_download_button",
 ]

--- a/tfbpshiny/modules/select_datasets/export.py
+++ b/tfbpshiny/modules/select_datasets/export.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
+import csv
 import io
 import logging
 import re
 import tarfile
+from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING
-
-import pandas as pd
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from duckdb import DuckDBPyConnection
     from labretriever import VirtualDB
 
 logger = logging.getLogger("shiny")
@@ -39,18 +39,19 @@ def _safe_dir_name(display_name: str) -> str:
 @dataclass(frozen=True)
 class ExportDataset:
     """
-    One dataset's worth of export data.
+    One dataset's export specification — SQL queries to execute, not materialised
+    DataFrames.
 
-    .. note::
-        ``frozen=True`` prevents attribute reassignment but does not prevent
-        in-place mutation of the contained DataFrames. Callers should treat
-        ``metadata_df`` and ``data_df`` as read-only.
+    Queries are executed lazily inside :func:`build_export_tarball` so that
+    only one dataset's data is in memory at a time.
 
     """
 
     display_name: str
-    metadata_df: pd.DataFrame
-    data_df: pd.DataFrame
+    metadata_sql: str
+    metadata_params: dict[str, Any]
+    data_sql: str
+    data_params: dict[str, Any]
     description: str | None = None
 
 
@@ -104,54 +105,127 @@ def get_dataset_description(vdb: VirtualDB, db_name: str) -> str | None:
         return config.description or None
     except Exception:
         logger.warning(
-            "Failed to retrieve DataCard description for %s (private API)", db_name
+            "Failed to retrieve DataCard description for %s (private API)",
+            db_name,
+            exc_info=True,
         )
         return None
 
 
-def build_export_tarball(datasets: list[ExportDataset], output_path: Path) -> Path:
+def _query_to_csv_bytes(
+    cursor: DuckDBPyConnection, sql: str, params: dict[str, Any]
+) -> bytes:
     """
-    Assemble a ``.tar.gz`` archive from a list of export datasets.
+    Execute a SQL query on a DuckDB cursor and return the result serialized as CSV bytes
+    with LF line endings.
+
+    Uses ``csv.writer`` instead of ``pd.DataFrame.to_csv`` to avoid pandas
+    serialization overhead.
+
+    .. todo:: Replace ``vdb._conn.cursor()`` access with public API (issue #213).
+
+    :param cursor: A DuckDB cursor (thread-safe for reads when each thread
+        holds its own cursor obtained via ``conn.cursor()``).
+    :param sql: SQL query string.
+    :param params: Bound parameter values.
+    :returns: UTF-8 encoded CSV bytes.
+
+    """
+    result = cursor.execute(sql, params) if params else cursor.execute(sql)
+    cols = [d[0] for d in result.description]
+    rows = result.fetchall()
+
+    buf = io.BytesIO()
+    wrapper = io.TextIOWrapper(buf, encoding="utf-8", newline="")
+    writer = csv.writer(wrapper, lineterminator="\n")
+    writer.writerow(cols)
+    writer.writerows(rows)
+    wrapper.flush()
+    wrapper.detach()
+    return buf.getvalue()
+
+
+def build_export_tarball(
+    datasets: list[ExportDataset],
+    vdb: VirtualDB,
+    progress_callback: Callable[[str], None] | None = None,
+) -> io.BytesIO:
+    """
+    Assemble a ``.tar.gz`` archive in memory from a list of export dataset
+    specifications.
 
     Each dataset becomes a subdirectory with a sanitized name (see
-    :func:`_safe_dir_name`).
-    The subdirectory contains ``metadata.csv``, ``annotated_features.csv``, and
-    optionally ``README.md`` (when the dataset has a description).
+    :func:`_safe_dir_name`).  SQL queries are executed one at a time via
+    :func:`_query_to_csv_bytes` so only one dataset's data is in memory at
+    once.
 
-    :param datasets: Datasets to include.
-    :param output_path: Path for the resulting ``.tar.gz`` file.
-    :returns: ``output_path``.
+    Uses ``tarfile`` pipe mode (``w|gz``) for streaming writes into an
+    in-memory ``BytesIO`` buffer — no temp files on disk.  The full buffer
+    is returned to the caller for chunked yielding.
+
+    A thread-safe DuckDB cursor is created via ``vdb._conn.cursor()`` so
+    this function can safely run in a worker thread while the main event
+    loop continues to use ``vdb._conn`` for reactive queries.
+
+    :param datasets: Dataset export specs (SQL queries, not DataFrames).
+    :param vdb: VirtualDB instance for executing queries.
+    :param progress_callback: Optional callable invoked with the display name
+        of each dataset after it has been written to the tarball.
+    :returns: ``BytesIO`` buffer positioned at the start, ready for reading.
 
     """
-    with tarfile.open(output_path, "w:gz") as tar:
-        for ds in datasets:
-            dir_name = _safe_dir_name(ds.display_name)
+    # Create a thread-local cursor so we don't race with the event loop's
+    # use of vdb._conn.  DuckDB cursors are safe for concurrent reads.
+    cursor = vdb._conn.cursor()
 
-            # metadata.csv
-            meta_buf = io.BytesIO()
-            ds.metadata_df.to_csv(meta_buf, index=False)
-            meta_buf.seek(0)
-            meta_info = tarfile.TarInfo(name=f"{dir_name}/metadata.csv")
-            meta_info.size = len(meta_buf.getvalue())
-            tar.addfile(meta_info, meta_buf)
+    out = io.BytesIO()
+    try:
+        with tarfile.open(mode="w|gz", fileobj=out) as tar:
+            for ds in datasets:
+                dir_name = _safe_dir_name(ds.display_name)
 
-            # annotated_features.csv
-            data_buf = io.BytesIO()
-            ds.data_df.to_csv(data_buf, index=False)
-            data_buf.seek(0)
-            data_info = tarfile.TarInfo(name=f"{dir_name}/annotated_features.csv")
-            data_info.size = len(data_buf.getvalue())
-            tar.addfile(data_info, data_buf)
+                # Query both files before writing either — if one fails,
+                # skip the entire dataset rather than leaving a partial
+                # directory.
+                try:
+                    meta_bytes = _query_to_csv_bytes(
+                        cursor, ds.metadata_sql, ds.metadata_params
+                    )
+                    data_bytes = _query_to_csv_bytes(
+                        cursor, ds.data_sql, ds.data_params
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to query dataset %s during export",
+                        ds.display_name,
+                    )
+                    continue
 
-            # README.md (optional)
-            if ds.description:
-                readme_content = build_readme(ds.display_name, ds.description)
-                readme_buf = io.BytesIO(readme_content.encode("utf-8"))
-                readme_info = tarfile.TarInfo(name=f"{dir_name}/README.md")
-                readme_info.size = len(readme_buf.getvalue())
-                tar.addfile(readme_info, readme_buf)
+                # metadata.csv
+                meta_info = tarfile.TarInfo(name=f"{dir_name}/metadata.csv")
+                meta_info.size = len(meta_bytes)
+                tar.addfile(meta_info, io.BytesIO(meta_bytes))
 
-    return output_path
+                # annotated_features.csv
+                data_info = tarfile.TarInfo(name=f"{dir_name}/annotated_features.csv")
+                data_info.size = len(data_bytes)
+                tar.addfile(data_info, io.BytesIO(data_bytes))
+
+                # README.md (optional)
+                if ds.description:
+                    readme_content = build_readme(ds.display_name, ds.description)
+                    readme_bytes = readme_content.encode("utf-8")
+                    readme_info = tarfile.TarInfo(name=f"{dir_name}/README.md")
+                    readme_info.size = len(readme_bytes)
+                    tar.addfile(readme_info, io.BytesIO(readme_bytes))
+
+                if progress_callback:
+                    progress_callback(ds.display_name)
+    finally:
+        cursor.close()
+
+    out.seek(0)
+    return out
 
 
 __all__ = [
@@ -160,4 +234,5 @@ __all__ = [
     "get_dataset_description",
     "build_export_tarball",
     "_safe_dir_name",
+    "_query_to_csv_bytes",
 ]

--- a/tfbpshiny/modules/select_datasets/export.py
+++ b/tfbpshiny/modules/select_datasets/export.py
@@ -1,0 +1,163 @@
+"""Pure-function helpers for exporting selected datasets as a tarball."""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from labretriever import VirtualDB
+
+logger = logging.getLogger("shiny")
+
+_SAFE_NAME_RE = re.compile(r"[^\w.\-]")
+
+
+def _safe_dir_name(display_name: str) -> str:
+    """
+    Sanitize a display name for use as a tarball directory entry.
+
+    Replaces any character outside ``[a-zA-Z0-9_.-]`` with ``_`` and strips
+    leading/trailing dots and underscores to prevent path traversal.
+
+    :param display_name: Raw display name.
+    :returns: Filesystem-safe directory name.
+
+    """
+    sanitized = _SAFE_NAME_RE.sub("_", display_name)
+    sanitized = sanitized.strip("_.")
+    return sanitized or "dataset"
+
+
+@dataclass(frozen=True)
+class ExportDataset:
+    """
+    One dataset's worth of export data.
+
+    .. note::
+        ``frozen=True`` prevents attribute reassignment but does not prevent
+        in-place mutation of the contained DataFrames. Callers should treat
+        ``metadata_df`` and ``data_df`` as read-only.
+
+    """
+
+    display_name: str
+    metadata_df: pd.DataFrame
+    data_df: pd.DataFrame
+    description: str | None = None
+
+
+def build_readme(display_name: str, description: str) -> str:
+    """
+    Build README.md content for a single dataset subdirectory.
+
+    :param display_name: Human-readable dataset name.
+    :param description: Dataset description from the DataCard config.
+    :returns: Markdown string.
+
+    """
+    return (
+        f"# {display_name}\n"
+        f"\n"
+        f"{description}\n"
+        f"\n"
+        f"## Contents\n"
+        f"\n"
+        f"- **metadata.csv** -- Sample-level metadata for this dataset. Each row\n"
+        f"  represents one sample (one regulator interrogation under specific\n"
+        f"  experimental conditions).\n"
+        f"\n"
+        f"- **annotated_features.csv** -- Full genomic data for this dataset. Each\n"
+        f"  row represents a measurement at a specific genomic feature (gene) for a\n"
+        f"  specific sample.\n"
+    )
+
+
+def get_dataset_description(vdb: VirtualDB, db_name: str) -> str | None:
+    """
+    Retrieve the DataCard config description for a dataset.
+
+    Uses private VirtualDB attributes; returns ``None`` on any failure.
+
+    .. todo:: Replace with public VirtualDB API when available (issue #213).
+
+    :param vdb: VirtualDB instance.
+    :param db_name: Dataset name.
+    :returns: Description string or ``None``.
+
+    """
+    try:
+        repo_id, config_name = vdb._db_name_map[db_name]
+        card = vdb._datacards.get(repo_id)
+        if card is None:
+            return None
+        config = card.get_config(config_name)
+        if config is None:
+            return None
+        return config.description or None
+    except Exception:
+        logger.warning(
+            "Failed to retrieve DataCard description for %s (private API)", db_name
+        )
+        return None
+
+
+def build_export_tarball(datasets: list[ExportDataset], output_path: Path) -> Path:
+    """
+    Assemble a ``.tar.gz`` archive from a list of export datasets.
+
+    Each dataset becomes a subdirectory with a sanitized name (see
+    :func:`_safe_dir_name`).
+    The subdirectory contains ``metadata.csv``, ``annotated_features.csv``, and
+    optionally ``README.md`` (when the dataset has a description).
+
+    :param datasets: Datasets to include.
+    :param output_path: Path for the resulting ``.tar.gz`` file.
+    :returns: ``output_path``.
+
+    """
+    with tarfile.open(output_path, "w:gz") as tar:
+        for ds in datasets:
+            dir_name = _safe_dir_name(ds.display_name)
+
+            # metadata.csv
+            meta_buf = io.BytesIO()
+            ds.metadata_df.to_csv(meta_buf, index=False)
+            meta_buf.seek(0)
+            meta_info = tarfile.TarInfo(name=f"{dir_name}/metadata.csv")
+            meta_info.size = len(meta_buf.getvalue())
+            tar.addfile(meta_info, meta_buf)
+
+            # annotated_features.csv
+            data_buf = io.BytesIO()
+            ds.data_df.to_csv(data_buf, index=False)
+            data_buf.seek(0)
+            data_info = tarfile.TarInfo(name=f"{dir_name}/annotated_features.csv")
+            data_info.size = len(data_buf.getvalue())
+            tar.addfile(data_info, data_buf)
+
+            # README.md (optional)
+            if ds.description:
+                readme_content = build_readme(ds.display_name, ds.description)
+                readme_buf = io.BytesIO(readme_content.encode("utf-8"))
+                readme_info = tarfile.TarInfo(name=f"{dir_name}/README.md")
+                readme_info.size = len(readme_buf.getvalue())
+                tar.addfile(readme_info, readme_buf)
+
+    return output_path
+
+
+__all__ = [
+    "ExportDataset",
+    "build_readme",
+    "get_dataset_description",
+    "build_export_tarball",
+    "_safe_dir_name",
+]

--- a/tfbpshiny/modules/select_datasets/queries.py
+++ b/tfbpshiny/modules/select_datasets/queries.py
@@ -205,9 +205,31 @@ def regulator_display_labels_query(db_name: str) -> tuple[str, dict]:
     )
 
 
+def full_data_query(
+    db_name: str, filters: dict[str, Any] | None = None
+) -> tuple[str, dict[str, Any]]:
+    """
+    Return ``(sql, params)`` for querying the dataset's full data view with optional
+    filters.
+
+    The full data view (``{db_name}``) includes all genomic data columns joined with
+    metadata columns.
+
+    :param db_name: Dataset name (e.g. ``'harbison'``).
+    :param filters: Active filters for this dataset — same structure as
+        :func:`metadata_query`.
+    :return: ``(sql_string, params_dict)`` ready for ``vdb.query(sql, **params)``.
+
+    """
+    params: dict[str, Any] = {}
+    where = _build_where(filters, params)
+    return f"SELECT * FROM {db_name}{where}", params
+
+
 __all__ = [
     "FIELD_TYPE_OVERRIDES",
     "metadata_query",
+    "full_data_query",
     "sample_count_query",
     "regulator_locus_tags_query",
     "regulator_breakdown_query",

--- a/tfbpshiny/modules/select_datasets/server/sidebar.py
+++ b/tfbpshiny/modules/select_datasets/server/sidebar.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
-import tempfile
+import io
 from logging import Logger
-from pathlib import Path
 from typing import Any
 
 import faicons as fa
@@ -547,9 +547,14 @@ def select_datasets_sidebar_server(
         filename=lambda: "tfbpshiny_export.tar.gz",
         media_type="application/gzip",
     )
-    def export_datasets():
+    async def export_datasets():
         """
         Build and stream a .tar.gz archive of all active datasets.
+
+        The tarball is built in a worker thread via ``asyncio.to_thread`` so
+        the Shiny event loop stays responsive.  A ``ui.Progress`` bar shows
+        live per-dataset progress via an ``asyncio.Queue`` bridged from the
+        worker thread with ``call_soon_threadsafe``.
 
         :trigger: ``input.export_datasets`` — fires when the user clicks the
             Export Selected Datasets download button.
@@ -560,43 +565,72 @@ def select_datasets_sidebar_server(
             return
 
         filters = dataset_filters()
-        export_list: list[ExportDataset] = []
+        n = len(all_active)
 
+        # Build ExportDataset specs (SQL + params, not DataFrames)
+        export_list: list[ExportDataset] = []
         for db_name in all_active:
             ds_filters = filters.get(db_name)
             display_name = dataset_dict[db_name].get("display_name", db_name)
 
-            try:
-                meta_sql, meta_params = metadata_query(db_name, ds_filters)
-                metadata_df = vdb.query(meta_sql, **meta_params)
-
-                data_sql, data_params = full_data_query(db_name, ds_filters)
-                data_df = vdb.query(data_sql, **data_params)
-            except Exception:
-                logger.exception("Failed to query dataset %s during export", db_name)
-                continue
-
+            meta_sql, meta_params = metadata_query(db_name, ds_filters)
+            data_sql, data_params = full_data_query(db_name, ds_filters)
             description = get_dataset_description(vdb, db_name)
 
             export_list.append(
                 ExportDataset(
                     display_name=display_name,
-                    metadata_df=metadata_df,
-                    data_df=data_df,
+                    metadata_sql=meta_sql,
+                    metadata_params=meta_params,
+                    data_sql=data_sql,
+                    data_params=data_params,
                     description=description,
                 )
             )
 
-        if not export_list:
-            return
+        # asyncio.Queue bridged from the worker thread for live progress.
+        # A None sentinel signals that the build is complete.
+        progress_q: asyncio.Queue[str | None] = asyncio.Queue()
+        loop = asyncio.get_running_loop()
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            tarball_path = build_export_tarball(
-                export_list, Path(tmp_dir) / "tfbpshiny_export.tar.gz"
-            )
-            with open(tarball_path, "rb") as f:
-                while chunk := f.read(65536):
-                    yield chunk
+        def _on_dataset_done(name: str) -> None:
+            loop.call_soon_threadsafe(progress_q.put_nowait, name)
+
+        def _build_and_signal() -> io.BytesIO:
+            try:
+                return build_export_tarball(export_list, vdb, _on_dataset_done)
+            finally:
+                loop.call_soon_threadsafe(progress_q.put_nowait, None)
+
+        with ui.Progress(min=0, max=n, session=session) as progress:
+            progress.set(0, message="Preparing export...")
+
+            build_task = asyncio.create_task(asyncio.to_thread(_build_and_signal))
+
+            # Consume progress items until the sentinel arrives
+            done = 0
+            while True:
+                name = await progress_q.get()
+                if name is None:
+                    break
+                done += 1
+                progress.set(
+                    done,
+                    message=f"Packaged {name}",
+                    detail=f"{done} of {n}",
+                )
+
+            try:
+                buf = await build_task
+            except Exception:
+                logger.exception("Export tarball build failed")
+                return
+
+            progress.set(n, message="Download ready")
+
+        # Yield chunks from the in-memory buffer
+        while chunk := buf.read(65536):
+            yield chunk
 
     @render.ui
     def sidebar_panel() -> ui.Tag:

--- a/tfbpshiny/modules/select_datasets/server/sidebar.py
+++ b/tfbpshiny/modules/select_datasets/server/sidebar.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import tempfile
 from logging import Logger
+from pathlib import Path
 from typing import Any
 
 import faicons as fa
@@ -11,8 +13,15 @@ import pandas as pd
 from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
+from tfbpshiny.components import export_download_button
+from tfbpshiny.modules.select_datasets.export import (
+    ExportDataset,
+    build_export_tarball,
+    get_dataset_description,
+)
 from tfbpshiny.modules.select_datasets.queries import (
     FIELD_TYPE_OVERRIDES,
+    full_data_query,
     metadata_query,
     regulator_display_labels_query,
 )
@@ -513,6 +522,61 @@ def select_datasets_sidebar_server(
         modal_open_for.set(None)
         modal_df.set(None)
 
+    @render.download(
+        filename=lambda: "tfbpshiny_export.tar.gz",
+        media_type="application/gzip",
+    )
+    def export_datasets():
+        """
+        Build and stream a .tar.gz archive of all active datasets.
+
+        :trigger: ``input.export_datasets`` — fires when the user clicks the
+            Export Selected Datasets download button.
+
+        """
+        all_active = _active_binding_datasets() + _active_perturbation_datasets()
+        if not all_active:
+            return
+
+        filters = dataset_filters()
+        export_list: list[ExportDataset] = []
+
+        for db_name in all_active:
+            ds_filters = filters.get(db_name)
+            display_name = dataset_dict[db_name].get("display_name", db_name)
+
+            try:
+                meta_sql, meta_params = metadata_query(db_name, ds_filters)
+                metadata_df = vdb.query(meta_sql, **meta_params)
+
+                data_sql, data_params = full_data_query(db_name, ds_filters)
+                data_df = vdb.query(data_sql, **data_params)
+            except Exception:
+                logger.exception("Failed to query dataset %s during export", db_name)
+                continue
+
+            description = get_dataset_description(vdb, db_name)
+
+            export_list.append(
+                ExportDataset(
+                    display_name=display_name,
+                    metadata_df=metadata_df,
+                    data_df=data_df,
+                    description=description,
+                )
+            )
+
+        if not export_list:
+            return
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tarball_path = build_export_tarball(
+                export_list, Path(tmp_dir) / "tfbpshiny_export.tar.gz"
+            )
+            with open(tarball_path, "rb") as f:
+                while chunk := f.read(65536):
+                    yield chunk
+
     @render.ui
     def sidebar_panel() -> ui.Tag:
         """
@@ -592,12 +656,10 @@ def select_datasets_sidebar_server(
                 )
             )
 
-        return ui.div(
-            {
-                "class": "context-sidebar selection-sidebar"
-                + (" collapsed" if is_collapsed else ""),
-                "id": "selection-sidebar",
-            },
+        has_active = bool(_active_binding_datasets() or _active_perturbation_datasets())
+        show_footer = has_active and not is_collapsed
+
+        children: list[Any] = [
             ui.div(
                 {"class": "sidebar-header"},
                 ui.div(
@@ -626,6 +688,23 @@ def select_datasets_sidebar_server(
                 {"class": "sidebar-body"},
                 ui.div({"class": "dataset-list"}, *section_tags),
             ),
+        ]
+
+        if show_footer:
+            children.append(
+                ui.div(
+                    {"class": "sidebar-footer"},
+                    export_download_button("export_datasets"),
+                )
+            )
+
+        return ui.div(
+            {
+                "class": "context-sidebar selection-sidebar"
+                + (" collapsed" if is_collapsed else ""),
+                "id": "selection-sidebar",
+            },
+            *children,
         )
 
     return _active_binding_datasets, _active_perturbation_datasets, dataset_filters

--- a/tfbpshiny/modules/select_datasets/server/sidebar.py
+++ b/tfbpshiny/modules/select_datasets/server/sidebar.py
@@ -13,6 +13,7 @@ import pandas as pd
 from labretriever import VirtualDB
 from shiny import module, reactive, render, ui
 
+from tfbpshiny import components
 from tfbpshiny.components import export_download_button
 from tfbpshiny.modules.select_datasets.export import (
     ExportDataset,


### PR DESCRIPTION
Add an "Export Selected Datasets" download button to the select_datasets sidebar footer. When clicked, it assembles a .tar.gz archive with one subdirectory per active dataset containing metadata.csv, annotated_features.csv, and optionally a README.md with the DataCard description.

New files:
- tfbpshiny/modules/select_datasets/export.py: pure-function tarball assembly logic with _safe_dir_name sanitization against path traversal
- tests/unit/test_export.py: 28 tests including adversarial display_name inputs

Changes:
- queries.py: add full_data_query() for filtered full data view
- components.py: add export_download_button() UI component
- app.css: export button and collapsed-sidebar footer styles
- server/sidebar.py: @render.download handler with error handling, chunked 64KB streaming, and conditional footer visibility

All changes have been reviewed by agents and me multiple times.

TODO: the description retrieval is still using a private attribute of vdb. Once a public api is implemented, this should be updated.