### PR TITLE
upgrading labretriever to 0.2.0 to retrieve citation from datacard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.11"
 # use `rev` to pin to a specific hash, or tag, from the git repo
-labretriever = {git = "https://github.com/cmatKhan/labretriever.git", rev = "72bbf3b"}
+labretriever = {git = "https://github.com/cmatKhan/labretriever.git", rev = "ecaa7e3"}
 shiny = "^1.4.0"
 shinywidgets = "^0.7.1"
 upsetjs-jupyter-widget = "^1.9.0"


### PR DESCRIPTION
See https://cmatkhan.github.io/labretriever/tutorials/virtual_db_tutorial/#citations for instructions on getting the citation from the datacard through virtualDB