### PR TITLE
Adding descriptions to vdb config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.11"
 # use `rev` to pin to a specific hash, or tag, from the git repo
-labretriever = {git = "https://github.com/cmatKhan/labretriever.git", rev = "ecaa7e3"}
+labretriever = {git = "https://github.com/cmatKhan/labretriever.git", rev = "9037f02"}
 shiny = "^1.4.0"
 shinywidgets = "^0.7.1"
 upsetjs-jupyter-widget = "^1.9.0"

--- a/tfbpshiny/brentlab_yeast_collection.yaml
+++ b/tfbpshiny/brentlab_yeast_collection.yaml
@@ -16,6 +16,10 @@ repositories:
           assay: CallingCards
           display_name: "2026 Calling Cards"
         db_name: callingcards
+        description: >-
+          Data generated with calling cards, a method that inserts transposons
+          near TF binding sites, from cells growing on synthetic complete media
+          at room temperature with galactose as the sole carbon source.
         sample_id:
           field: gm_id
 
@@ -57,6 +61,10 @@ repositories:
           data_type: binding
           assay: ChIPexo
           display_name: "2021 ChIP-exo (Rossi)"
+        description: >-
+          ChIP-exo (a variant of ChIP-seq) data, primarily in YPD batch
+          cultures at 25C. Includes DNA-binding transcription factors and
+          many other chromatin factors.
         db_name: rossi
         sample_id:
           field: sample_id
@@ -112,6 +120,10 @@ repositories:
           data_type: perturbation
           assay: ChIPexo
           display_name: "2025 Degron (Mahendrawada)"
+        description: >-
+          RNA-seq expression data generated from nascent RNA (4TU labelling and
+          purification) following depletion of a given TF via the auxin-inducible
+          degron system.
         db_name: degron
         sample_id:
           field: sample_id


### PR DESCRIPTION
this versions labretriever to 0.3.0. that has a doi field and citation field in the datacard now, per issue #240.

labretriever 0.3.0 also allows for a dataset description in the vdb config that overrides the datacard description. This is b/c the datacard description can serve a different purpose, denoting how a given dataset differs from others (different promoters, etc) while the vdb config description will be user facing